### PR TITLE
chore: sync config files from .config-templates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,19 @@
 {
-	"name": "Python 3",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
-	"onCreateCommand": ".devcontainer/startup.sh",
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"python.testing.pytestEnabled": true,
-				"python.testing.unittestEnabled": false,
-				"python.testing.pytestArgs": [
-					"."
-				],
-				"python.pythonPath": ".venv/bin/python",
-				"python.defaultInterpreterPath": ".venv/bin/python",
-				"python.terminal.activateEnvInCurrentTerminal": true
-			},
-			"extensions": [
-				"ms-toolsai.jupyter"
-			]
-		}
-	}
+  "name": "Marimo Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "hostRequirements": {
+    "cpus": 4
+  },
+  "forwardPorts": [8080],
+  "postCreateCommand": "curl -LsSf https://astral.sh/uv/install.sh | sh && uv venv && ([ -f pyproject.toml ] && uv sync --all-extras || true) && uv pip install marimo",
+  "postStartCommand": "[ -f .venv/bin/activate ] && uv run marimo --yes edit --host=localhost --port=8080 --headless --no-token || echo '⚠️ Marimo failed to start'",
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "marimo-ai.marimo-vscode"
+      ]
+    }
+  }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+root = true
+
+[*.{py,rst,txt}]
+indent_style = space
+trim_trailing_whitespace = true
+indent_size = 4
+end_of_line = LF
+
+[*.yml]
+indent_style = space
+indent_size = 2
+end_of_line = LF

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,76 +1,27 @@
-# cvxbson Code of Conduct
+# Code of Conduct
 
-## Our Pledge
+## Purpose
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+This code of conduct outlines expectations for behavior when participating in the project with the aim of fostering a constructive and professional engineering environment.
 
-## Our Standards
+## Expected Behavior
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Participants are expected to:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+- Be respectful in communication and collaboration.
+- Focus on technical topics and project goals.
+- Accept constructive feedback gracefully and offer it in kind.
+- Assume good intentions from others and engage with a problem-solving mindset.
+- Use appropriate language and conduct in all community spaces.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies in all project spaces—online and offline—and also applies when individuals are representing the project in public spaces.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting any member of the project team. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Project maintainers are responsible for enforcing the code and may take proportionate corrective action in response to unexpected behavior.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.4, available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
-
-[homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-<https://www.contributor-covenant.org/faq>
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), with modifications for brevity and neutrality.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to cvxbson
+# Contributing
 
-This document is a guide to contributing to cvxbson
+This document is a guide to contributing to the project.
 
-We welcome all contributions. You don't need to be an expert (in optimization)
+We welcome all contributions. You don't need to be an expert
 to help out.
 
 ## Checklist
@@ -11,70 +11,70 @@ Contributions are made through
 [pull requests](https://help.github.com/articles/using-pull-requests/).
 Before sending a pull request, make sure you do the following:
 
-- Run 'make fmt' to make sure your code adheres to our [coding style](#code-style).
-  This step also includes our license on top of your new files.
-- [Write unit tests](#writing-unit-tests)
-- Run the [unit tests](#running-unit-tests) and check that they're passing
+- Run 'make check' to make sure your code adheres to our [coding style](#code-style)
+and all tests pass.
+- [Write unit tests](#writing-unit-tests) for new functionality added.
 
-## Building cvxbson from source
 
-You'll need to build cvxbson locally in order to start editing code.
-Please install [task](https://taskfile.dev).
+## Building from source
 
-To install cvxbson from source, clone the Github
+You'll need to build the project locally in order to start editing code.
+To install from source, clone the GitHub
 repository, navigate to its root, and run the following command:
 
 ```bash
-task cvxbson:install
+make install
 ```
 
 ## Contributing code
 
-To contribute to cvxbson, send us pull requests.
-For those new to contributing, check out Github's
+To contribute to the project, send us pull requests.
+For those new to contributing, check out GitHub's
 [guide](https://help.github.com/articles/using-pull-requests/).
 
-Once you've made your pull request, a member of the cvxbson
-development team will assign themselves to review it. You might have a few
-back-and-forths with your reviewer before it is accepted, which is completely normal.
-Your pull request will trigger continuous integration tests for many different
-Python versions and different platforms. If these tests start failing, please
+Once you've made your pull request, a member of the
+development team will assign themselves to review it.
+You might have a few
+back-and-forths with your reviewer before it is accepted,
+which is completely normal.
+Your pull request will trigger continuous integration tests
+for many different
+Python versions and different platforms. If these tests start failing,
+please
 fix your code and send another commit, which will re-trigger the tests.
 
-If you'd like to add a new feature to cvxbson, please do propose your
-change on a GitHub issue, to make sure that your priorities align with ours.
+If you'd like to add a new feature, please do propose your
+change on a GitHub issue, to make sure
+that your priorities align with ours.
 
-If you'd like to contribute code but don't know where to start, try one of the
+If you'd like to contribute code but don't know where to start,
+try one of the
 following:
 
-- Read the cvxbson source and enhance the documentation,
+- Read the source and enhance the documentation,
   or address TODOs
-- Browse the [issue tracker](https://github.com/cvxgrp/cvxbson/issues),
+- Browse the open issues,
   and look for the issues tagged "help wanted".
-
-## License
-
-A license is added to new files automatically as a pre-commit hook.
 
 ## Code style
 
-We use black and ruff to enforce our Python coding style.
-Before sending us a pull request, navigate to the project root
-and run
+We use ruff to enforce our Python coding style.
+Before sending us a pull request, navigate to the project 
+root and run
 
 ```bash
-task cvxbson:fmt
+make check
 ```
 
-to make sure that your changes abide by our style conventions. Please fix any
-errors that are reported before sending the pull request.
+to make sure that your changes abide by our style conventions.
+Please fix any errors that are reported before sending
+the pull request.
 
 ## Writing unit tests
 
-Most code changes will require new unit tests. Even bug fixes require unit tests,
+Most code changes will require new unit tests.
+Even bug fixes require unit tests,
 since the presence of bugs usually indicates insufficient tests.
-cvxbson tests live in the directory `tests`,
-which contains many files, each of which contains many unit tests.
 When adding tests, try to find a file in which your tests should belong;
 if you're testing a new feature, you might want to create a new test file.
 
@@ -87,13 +87,8 @@ We use `pytest` to run our unit tests.
 To run all unit tests run the following command:
 
 ```bash
-task cvxbson:test
+make test
 ```
 
-We keep a close eye on our coverage via
-
-```bash
-task cvxbson:coverage
-```
-
-Please make sure that your change doesn't cause any of the unit tests to fail.
+Please make sure that your change doesn't cause any
+of the unit tests to fail.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
         "pep621",
         "pre-commit",
         "github-actions",
-        "dockerfile"
+        "devcontainer"
     ],
     "timezone": "Asia/Dubai",
     "schedule": [

--- a/.github/taskfiles/build.yml
+++ b/.github/taskfiles/build.yml
@@ -1,0 +1,47 @@
+version: '3'
+
+tasks:
+  uv:
+    desc: Install uv and uvx
+    cmds:
+      - curl -sSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1 || (echo "${RED}Installation failed!${RESET}" >&2; exit 1)
+      - export PATH="$HOME/.cargo/bin:$PATH"
+
+  install:
+    desc: Install all dependencies using uv
+    deps: [uv]
+    cmds:
+      - |
+        # Check if .venv folder already exists
+        if [ -d ".venv" ]; then
+          printf "${BLUE}[INFO] Virtual environment already exists, skipping installation${RESET}\n"
+        else
+          # we need the virtual environment at least for the tests to work
+          # even if we don't install anything
+          
+          # Create the virtual environment
+          printf "${BLUE}[INFO] Creating virtual environment...${RESET}\n"
+          
+          # Create the virtual environment
+          uv venv --python 3.12 || { printf "${RED}[ERROR] Failed to create virtual environment${RESET}\n"; exit 1; }
+          
+          if [ -f "pyproject.toml" ]; then
+            printf "${BLUE}[INFO] Installing dependencies${RESET}\n"
+            uv sync --all-extras --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }
+          else
+            printf "${YELLOW}[WARN] No pyproject.toml found, skipping install${RESET}\n"
+          fi
+        fi
+
+  build:
+    desc: Build the package using hatch
+    deps: [install]
+    cmds:
+      - |
+        if [ -f "pyproject.toml" ]; then
+          printf "${BLUE}[INFO] Building package...${RESET}\n"
+          uv pip install hatch
+          uv run hatch build
+        else
+          printf "${YELLOW}[WARN] No pyproject.toml found, skipping build${RESET}\n"
+        fi

--- a/.github/taskfiles/cleanup.yml
+++ b/.github/taskfiles/cleanup.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+tasks:
+  clean:
+    desc: Clean generated files and directories
+    cmds:
+      - |
+        printf " ${BLUE}[INFO] Cleaning project...${RESET}\n"
+        git clean -d -X -f
+        rm -rf dist build *.egg-info .coverage .pytest_cache
+        printf " ${BLUE}[INFO] Removing local branches with no remote counterpart...${RESET}\n"
+        git fetch --prune
+        git branch -vv \
+          | grep ': gone]' \
+          | awk '{print $1}' \
+          | xargs -r git branch -D 2>/dev/null || true

--- a/.github/taskfiles/docs.yml
+++ b/.github/taskfiles/docs.yml
@@ -1,0 +1,140 @@
+version: '3'
+
+includes:
+  build:
+    taskfile: ./build.yml
+    internal: true
+
+tasks:
+  test:
+    desc: Run all tests
+    cmds:
+      - task build:install -s
+      - printf "${BLUE}[INFO] Running tests...${RESET}\n"
+      - |
+        # Find source folder
+        SOURCE_FOLDER="src/$(find src -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*' | head -1 | sed 's|^src/||')"
+        
+        if [ -z "$SOURCE_FOLDER" ] || [ -z "{{.TESTS_FOLDER}}" ]; then
+          printf "${YELLOW}[WARN] No valid source folder structure found, skipping tests${RESET}\n"
+        else
+          uv pip install pytest pytest-cov pytest-html
+          mkdir -p _tests/html-coverage _tests/html-report
+          uv run pytest {{.TESTS_FOLDER}} --cov=$SOURCE_FOLDER --cov-report=term --cov-report=html:_tests/html-coverage --html=_tests/html-report/report.html
+        fi
+
+  docs:
+    desc: Build documentation using pdoc
+    cmds:
+      - task build:install -s
+      - |
+        if [ -f "pyproject.toml" ]; then
+          printf "${BLUE}[INFO] Building documentation...${RESET}\n"
+          SOURCE_FOLDER=src/$(find src -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*' | head -1)
+          uv pip install pdoc
+          uv run pdoc -o _pdoc "$SOURCE_FOLDER"
+        else
+          printf "${YELLOW}[WARN] No pyproject.toml found, skipping docs${RESET}\n"
+        fi
+  
+  marimushka:
+    desc: Export Marimo notebooks to HTML
+    cmds:
+      - task build:install -s
+      - printf "${BLUE}[INFO] Exporting notebooks from {{.MARIMO_FOLDER}}...${RESET}\n"
+      - |
+        if [ ! -d "{{.MARIMO_FOLDER}}" ]; then
+          printf "${YELLOW}[WARN] Directory '{{.MARIMO_FOLDER}}' does not exist. Skipping marimushka.${RESET}\n"
+        else
+          mkdir -p _marimushka
+          py_files=$(find "{{.MARIMO_FOLDER}}" -maxdepth 1 -name "*.py" | tr '\n' ' ')
+          if [ -z "$py_files" ]; then
+            printf "${YELLOW}[WARN] No Python files found in '{{.MARIMO_FOLDER}}'.${RESET}\n"
+            echo "<html><head><title>Marimo Notebooks</title></head><body><h1>Marimo Notebooks</h1><p>No notebooks found.</p></body></html>" > _marimushka/index.html
+          else
+            printf "${BLUE}[INFO] Found Python files: %s${RESET}\n" "$py_files"
+            for py_file in $py_files; do
+              printf " ${BLUE}[INFO] Processing %s...${RESET}\n" "$py_file"
+              rel_path=$(echo "$py_file" | sed "s|^{{.MARIMO_FOLDER}}/||")
+              dir_path=$(dirname "$rel_path")
+              base_name=$(basename "$rel_path" .py)
+              mkdir -p "_marimushka/$dir_path"
+              uvx marimo export html --include-code --sandbox --output "_marimushka/$dir_path/$base_name.html" "$py_file"
+            done
+            echo "<html><head><title>Marimo Notebooks</title></head><body><h1>Marimo Notebooks</h1><ul>" > _marimushka/index.html
+            find _marimushka -name "*.html" -not -path "*index.html" | sort | while read html_file; do
+              rel_path=$(echo "$html_file" | sed "s|^_marimushka/||")
+              name=$(basename "$rel_path" .html)
+              echo "<li><a href=\"$rel_path\">$name</a></li>" >> _marimushka/index.html
+            done
+            echo "</ul></body></html>" >> _marimushka/index.html
+            touch _marimushka/.nojekyll
+          fi
+        fi
+  
+  book:
+    desc: Build the companion book with test results and notebooks
+    cmds:
+      - printf "${BLUE}[INFO] Building combined documentation...${RESET}\n"
+      - printf "${BLUE}[INFO] Delete the _book folder...${RESET}\n"
+      - rm -rf _book
+      - printf "${BLUE}[INFO] Create empty _book folder...${RESET}\n"
+      - mkdir -p _book
+      - touch _book/links.json
+      - |
+        printf "${BLUE}[INFO] Copy API docs...${RESET}\n"
+        if [ -d _pdoc ]; then
+          mkdir -p _book/pdoc
+          cp -r _pdoc/* _book/pdoc
+          echo '{"API": "./pdoc/index.html"}' > _book/links.json
+        else
+          echo '{}' > _book/links.json
+        fi
+        
+        printf "${BLUE}[INFO] Copy coverage report...${RESET}\n"
+        if [ -d _tests/html-coverage ] && [ "$(ls -A _tests/html-coverage 2>/dev/null)" ]; then
+          mkdir -p _book/tests/html-coverage
+          cp -r _tests/html-coverage/* _book/tests/html-coverage
+          jq '. + {"Coverage": "./tests/html-coverage/index.html"}' _book/links.json > _book/tmp && mv _book/tmp _book/links.json
+        else
+          printf "${YELLOW}[WARN] No coverage report found or directory is empty${RESET}\n"
+        fi
+        
+        printf "${BLUE}[INFO] Copy test report...${RESET}\n"
+        if [ -d _tests/html-report ] && [ "$(ls -A _tests/html-report 2>/dev/null)" ]; then
+          mkdir -p _book/tests/html-report
+          cp -r _tests/html-report/* _book/tests/html-report
+          jq '. + {"Test Report": "./tests/html-report/report.html"}' _book/links.json > _book/tmp && mv _book/tmp _book/links.json
+        else
+          printf "${YELLOW}[WARN] No test report found or directory is empty${RESET}\n"
+        fi
+        
+        printf "${BLUE}[INFO] Copy notebooks...${RESET}\n"
+        if [ -d _marimushka ] && [ "$(ls -A _marimushka 2>/dev/null)" ]; then
+          mkdir -p _book/marimushka
+          cp -r _marimushka/* _book/marimushka
+          jq '. + {"Notebooks": "./marimushka/index.html"}' _book/links.json > _book/tmp && mv _book/tmp _book/links.json
+          printf "${BLUE}[INFO] Copied notebooks from {{.MARIMO_FOLDER}} to _book/marimushka${RESET}\n"
+        else
+          printf "${YELLOW}[WARN] No notebooks found or directory is empty${RESET}\n"
+        fi
+        
+        printf "${BLUE}[INFO] Generated links.json:${RESET}\n"
+        cat _book/links.json
+        
+        uvx minibook@v0.0.16 --title "{{.BOOK_TITLE}}" --subtitle "{{.BOOK_SUBTITLE}}" --links "$(cat _book/links.json)" --output "_book"
+        
+        touch "_book/.nojekyll"
+  
+  marimo:
+    desc: Start a Marimo server
+    cmds:
+      - task build:install -s
+      - printf " ${BLUE}[INFO] Start Marimo server with {{.MARIMO_FOLDER}}...${RESET}\n"
+      - |
+        if [ ! -d "{{.MARIMO_FOLDER}}" ]; then
+          printf " ${YELLOW}[WARN] Marimo folder '{{.MARIMO_FOLDER}}' not found, skipping start${RESET}\n"
+        else
+          uv pip install marimo
+          uv run marimo edit "{{.MARIMO_FOLDER}}"
+        fi

--- a/.github/taskfiles/docs.yml
+++ b/.github/taskfiles/docs.yml
@@ -30,9 +30,13 @@ tasks:
       - |
         if [ -f "pyproject.toml" ]; then
           printf "${BLUE}[INFO] Building documentation...${RESET}\n"
-          SOURCE_FOLDER=src/$(find src -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*' | head -1)
-          uv pip install pdoc
-          uv run pdoc -o _pdoc "$SOURCE_FOLDER"
+          if [ -d "src" ]; then
+            SOURCE_FOLDER=src/$(find src -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*' | sort | head -1)
+            uv pip install pdoc
+            uv run pdoc -o _pdoc "$SOURCE_FOLDER"
+          else
+            printf "${YELLOW}[WARN] No src/ directory found, skipping docs${RESET}\n"
+          fi
         else
           printf "${YELLOW}[WARN] No pyproject.toml found, skipping docs${RESET}\n"
         fi

--- a/.github/taskfiles/quality.yml
+++ b/.github/taskfiles/quality.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+includes:
+  build:
+    taskfile: ./build.yml
+    internal: true
+
+
+tasks:
+  fmt:
+    desc: Format code using Ruff
+    cmds:
+      - task build:uv -s
+      - printf "${BLUE}[INFO] Running formatters...${RESET}\n"
+      - uvx ruff format .
+
+  lint:
+    desc: Run pre-commit hooks
+    cmds:
+      - task build:uv -s
+      - printf "${BLUE}[INFO] Running linters...${RESET}\n"
+      - uvx pre-commit run --all-files
+
+  deptry:
+    desc: Check for dependency issues
+    cmds:
+      - task build:uv -s
+      - printf "${BLUE}[INFO] Running deptry...${RESET}\n"
+      - |
+        if [ -f "pyproject.toml" ]; then
+          SOURCE_FOLDER="src/$(find src -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*' | head -1 | sed 's|^src/||')"
+          uvx deptry $SOURCE_FOLDER {{.OPTIONS}}
+        else
+          printf "${YELLOW}[WARN] No pyproject.toml found, skipping deptry${RESET}\n"
+        fi
+  
+  check:
+    desc: Run all code quality checks
+    deps: [lint, fmt, deptry]
+    cmds:
+      - printf "${GREEN}[INFO] All checks passed!${RESET}\n"

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,68 +1,89 @@
-name: "book"
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+# Workflow: Book
+# Purpose: This workflow builds and deploys comprehensive documentation for the project.
+#          It combines API documentation, test coverage reports, test results, and
+#          interactive notebooks into a single GitHub Pages site.
+#
+# Trigger: This workflow runs on every push to the main branch
+#
+# Components:
+#   - 📚 Parse .env file for configuration
+#   - 📓 Process Marimo notebooks
+#   - 📖 Generate API documentation with pdoc
+#   - 🧪 Run tests and generate coverage reports
+#   - 🚀 Deploy combined documentation to GitHub Pages
 
-# This workflow builds and publishes documentation for the cvxbson repository
-# It runs automatically on every push to the repository
-# The workflow includes multiple documentation generation jobs and combines them into a final book
+name: "BOOK"
 
-# Trigger the workflow on push events
-# This ensures the documentation is automatically updated whenever code changes are pushed to main
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
 
 jobs:
-  # Generates interactive Marimo notebooks for documentation
-  marimo:
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: jebel-quant/marimushka@v0.1.5
-        with:
-          notebooks: 'book/marimo'
-
-
-  # Runs tests and generates coverage reports for the source code
-  test:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: cvxgrp/.github/actions/environment@v2.2.8
-
-      - uses: cvxgrp/.github/actions/coverage@v2.2.8
-        with:
-          source-folder: 'src/cvx'
-          tests-folder: 'tests'
-
-  # Processes Jupyter notebooks for documentation
-  jupyter:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: cvxgrp/.github/actions/environment@v2.2.8
-
-      - uses: cvxgrp/.github/actions/jupyter@v2.2.8
-
-  # Generates API documentation using pdoc for the source code
-  pdoc:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: cvxgrp/.github/actions/environment@v2.2.8
-
-      - uses: cvxgrp/.github/actions/pdoc@v2.2.8
-        with:
-          source-folder: 'src/cvx'
-
-  # Combines all documentation outputs into a final book
-  # This job only runs after all other jobs have completed successfully
-  # Requires permissions to write to repository contents and GitHub Pages
   book:
     runs-on: "ubuntu-latest"
-    needs: [test, jupyter, marimo, pdoc]
+
+    environment:
+      name: github-pages  # 👈 this is the critical missing piece
 
     permissions:
-      contents: write
-      pages: write
+      contents: read
+      pages: write            # Permission to deploy to Pages
+      id-token: write         # Permission to verify deployment origin
 
     steps:
-      - uses: cvxgrp/.github/actions/book@v2.2.8
+      # Check out the repository code
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Make the docs"
+        run: |
+          task docs:docs
+
+      - name: "Make the tests"
+        run: |
+          task docs:test
+
+      - name: "Make the notebooks"
+        run: |
+          task docs:marimushka
+
+      - name: "Make the book"
+        run: |
+          task docs:book
+
+      # Step 4: Display the structure of the artifacts directory
+      # This helps with debugging by showing what files were generated
+      - name: Inspect artifacts
+        shell: bash
+        run: |
+          # Check if tree is installed, otherwise use find/ls as fallback
+          if command -v tree &> /dev/null; then
+            tree _book  # Show directory structure in tree format
+          else
+            echo "tree command not found, using fallback:"
+            find _book -type f | sort
+          fi
+
+      # Step 5: Package all artifacts for GitHub Pages deployment
+      # This prepares the combined outputs for deployment by creating a single artifact
+      - name: Upload static files as artifact
+        uses: actions/upload-pages-artifact@v3  # Official GitHub Pages artifact upload action
+        with:
+          path: _book/  # Path to the directory containing all artifacts to deploy
+
+      # Step 6: Deploy the packaged artifacts to GitHub Pages
+      # This step publishes the content to GitHub Pages
+      - name: Deploy to GitHub Pages
+        if: ${{ !github.event.repository.fork }}
+        uses: actions/deploy-pages@v4  # Official GitHub Pages deployment action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,68 @@
-name: "CI"
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+# Workflow: Continuous Integration
+# Purpose: This workflow runs tests on multiple Python versions to ensure
+#          compatibility and code quality across different environments.
+#
+# Trigger: This workflow runs on every push
+#
+# Components:
+#   - 🧪 Run tests on multiple Python versions
+#   - 🔄 Matrix strategy for testing on different environments
 
-# This workflow runs continuous integration tests across multiple platforms and Python versions
-# It runs automatically on every push to the repository
-# The workflow ensures the code works consistently across different environments
+name: "CI"
 
 on:
 - push
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    # if: github.repository != 'tschm/.config-templates'
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        # mongo container action only supported on Linux
+        os: [ ubuntu-latest ]
+        python-version: [ '3.11', '3.12', '3.13' ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: cvxgrp/.github/actions/environment@v2.2.8
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
-      - uses: cvxgrp/.github/actions/test@v2.2.8
+      # This installs Python and uv for faster dependency management
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v6  # Official action for setting up uv
         with:
-          tests-folder: tests
+          python-version: ${{ matrix.python-version }}  # Use the specified Python version
+
+
+      # task is needed as we test the taskfiles
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the virtual environment
+        run: uv venv
+
+      - name: "Build the virtual environment for ${{ github.repository }}"
+        if: hashFiles('pyproject.toml') != ''
+        run:
+          uv sync --all-extras
+
+        #uses: tschm/cradle/actions/environment@v0.3.06
+        #with:
+        #  python-version: ${{ matrix.python-version }}
+
+      - name: "Run the tests"
+        run: |
+          uv pip install pytest
+          uv run pytest tests

--- a/.github/workflows/deptry.yml
+++ b/.github/workflows/deptry.yml
@@ -1,0 +1,57 @@
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+# Workflow: Deptry
+# Purpose: This workflow identifies missing and obsolete dependencies in the project.
+#          It helps maintain a clean dependency tree by detecting unused packages and
+#          implicit dependencies that should be explicitly declared.
+name: "DEPTRY"
+
+# Trigger: This workflow runs on every push and on pull requests to the main branch
+on:
+  push:
+  pull_request:
+    # Only run on pull requests targeting the main branch
+    branches: [ main ]
+
+# Permissions: Only read access to repository contents is needed
+permissions:
+    contents: read
+
+jobs:
+  check_pyproject:
+    name: Check pyproject.toml presence
+    runs-on: ubuntu-latest
+    outputs:
+      pyproject_exists: ${{ steps.check_file.outputs.exists }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check for pyproject.toml
+        id: check_file
+        run: |
+          if [ -f "pyproject.toml" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  deptry_analysis:
+    name: Run deptry if pyproject.toml exists
+    needs: check_pyproject
+    runs-on: ubuntu-latest
+    if: needs.check_pyproject.outputs.pyproject_exists == 'true'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run deptry
+        run: task quality:deptry

--- a/.github/workflows/marimo.yml
+++ b/.github/workflows/marimo.yml
@@ -1,0 +1,79 @@
+# This workflow runs and tests all Marimo notebooks in the project
+# It creates a matrix of jobs, one for each notebook, and runs them in parallel
+name: "Marimo"
+permissions:
+  contents: read
+
+on:
+  push
+
+jobs:
+  # Parse .env file and build a matrix of notebooks to test
+  list-notebooks:
+    runs-on: ubuntu-latest
+    outputs:
+      notebook-list: ${{ steps.notebooks.outputs.matrix }}
+    steps:
+      # Check out the repository code
+      - uses: actions/checkout@v5
+
+      # Find all Python files in the marimo folder and create a matrix for parallel execution
+      - name: Find notebooks and build matrix
+        id: notebooks
+        run: |
+          NOTEBOOK_DIR="book/marimo"
+          echo "Searching notebooks in: $NOTEBOOK_DIR"
+          # Check if directory exists
+          if [ ! -d "$NOTEBOOK_DIR" ]; then
+            echo "Directory $NOTEBOOK_DIR does not exist. Setting empty matrix."
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          
+          # Find notebooks and handle empty results
+          if [ -z "$(find "$NOTEBOOK_DIR" -maxdepth 1 -name "*.py" 2>/dev/null)" ]; then
+            echo "No notebooks found in $NOTEBOOK_DIR. Setting empty matrix."
+            echo "matrix=[]" >> "$GITHUB_OUTPUT"
+          else
+            notebooks=$(find "$NOTEBOOK_DIR" -maxdepth 1 -name "*.py" -print0 | xargs -0 -n1 echo | jq -R -s -c 'split("\n")[:-1]')
+            echo "matrix=$notebooks" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+  # Create one job per notebook using the matrix strategy for parallel execution
+  test-notebooks:
+    if: needs.list-notebooks.outputs.notebook-list != '[]'
+    runs-on: ubuntu-latest
+    needs: list-notebooks
+    strategy:
+      matrix:
+        notebook: ${{ fromJson(needs.list-notebooks.outputs.notebook-list) }}
+      # Don't fail the entire workflow if one notebook fails
+      fail-fast: false
+    name: Run notebook ${{ matrix.notebook }}
+    steps:
+      # Check out the repository code
+      - uses: actions/checkout@v5
+
+      # install uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      # install task
+      - name: Install task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Install Python dependencies
+      - name: Install uv, uvx and the environment
+        run: |
+          task build:install -s
+        shell: bash
+
+      # Execute the notebook with the appropriate runner based on its content
+      - name: Run notebook
+        run: |
+          uv run "${{ matrix.notebook }}"
+        shell: bash

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,28 +1,46 @@
-name: pre-commit
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+# Workflow: Pre-commit
+# Purpose: This workflow runs pre-commit checks to ensure code quality
+#          and consistency across the codebase. It helps catch issues
+#          like formatting errors, linting issues, and other code quality
+#          problems before they are merged.
+#
+# Trigger: This workflow runs on every push
+#
+# Components:
+#   - 🔍 Run pre-commit checks using reusable action
 
-# This workflow runs code quality checks and dependency analysis
-# It runs automatically on every push to the repository
-# The workflow ensures code meets quality standards and has no dependency issues
+name: "PRE-COMMIT"
 
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
-  # Analyzes project dependencies to detect unused or missing dependencies
-  # Uses deptry tool to scan the specified source folder
-  deptry:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Build the virtual environment for ${{ github.repository }}"
-        uses: cvxgrp/.github/actions/environment@v2.2.8
-
-      - uses: cvxgrp/.github/actions/deptry@v2.2.8
-        with:
-          source-folder: 'src/cvx'
-
-  # Runs pre-commit hooks on all files in the repository
-  # Checks code formatting, linting, and other quality checks
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: cvxgrp/.github/actions/pre-commit@v2.2.8
+      # Check out the repository code
+      - uses: actions/checkout@v5
+
+      # install uv and task
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint
+        run: |
+          task quality:lint
+
+      - name: Format
+        run: |
+          task quality:fmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,141 @@
-name: Bump version and publish
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+# Manual Release Workflow for Python Package using Hatch and
+# Trusted Publisher (OIDC)
+#
+# This workflow implements a secure, maintainable release pipeline
+# by separating concerns:
+#   - 🔖 Tagging the release (Git tag)
+#   - 🏗️ Building the package with Hatch
+#   - 🚀 Publishing to PyPI using OIDC (no passwords or secrets)
+#
+# 🔐 Security:
+#   - No PyPI credentials are stored; relies on Trusted Publishing via GitHub OIDC.
+#
+# 📄 Requirements:
+#   - `pyproject.toml` with a top-level `version = "..."`
+#   - Package is registered on PyPI as a Trusted Publisher with this repository
+#
+# ✅ To trigger:
+#   - Go to the "Actions" tab
+#   - Run this workflow manually with a tag input like `v1.2.3`
 
-# This workflow creates a new version tag and publishes the package to PyPI
-# It runs only when manually triggered via the GitHub Actions interface
-# The workflow first creates a tag based on the repository's version information, then publishes to PyPI
+name: Release Workflow
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v1.2.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write  # Needed to create releases
+  id-token: write  # Needed for OIDC authentication with PyPI
 
 jobs:
   tag:
-    permissions:
-      contents: write
-
+    name: Create Git Tag
     runs-on: ubuntu-latest
-
     steps:
-      - name: Generate Tag
-        uses: cvxgrp/.github/actions/tag@v2.2.8
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout Code
+        uses: actions/checkout@v5
 
-  publish:
+      - name: Create Git Tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git tag ${{ github.event.inputs.tag }}
+          git push origin ${{ github.event.inputs.tag }}
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
     needs: tag
-    runs-on: ubuntu-latest
-    environment: release
-
-    permissions:
-      contents: read
-      # This permission is required for trusted publishing.
-      id-token: write
-
     steps:
-      - uses: actions/download-artifact@v5
+      - name: Checkout Code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        if: hashFiles('pyproject.toml') != ''
+        run: |
+          version=${{ github.event.inputs.tag }}
+          version=${version#v}
+          echo "Setting version to $version"
+          sed -i.bak "s/^version = .*/version = \"$version\"/" pyproject.toml
+          rm pyproject.toml.bak
+
+          task build:build -s
+
+      - name: Upload dist artifact
+        # not tested at runtime!
+        if: hashFiles('pyproject.toml') != ''
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
 
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [tag, build]
+
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: dist
+        continue-on-error: true
+
+      - name: Create GitHub Release with artifacts
+        uses: softprops/action-gh-release@v2.3.2
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          name: ${{ github.event.inputs.tag }}
+          generate_release_notes: true
+          files: "dist/**"
+
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    needs: [build, tag]
+
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: dist
+        continue-on-error: true
+
+      - name: Check if dist contains artifacts
+        id: check_dist
+        run: |
+          if [[ ! -d dist ]]; then
+            echo "::warning::No folder dist/. Skipping PyPI publish."
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to PyPI
+        if: steps.check_dist.outputs.should_publish == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,28 @@
-.idea
-.task
-
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+docs
 .DS_Store
+_pdoc
+_book
+_tests
+_marimushka
 
+# temp file used by Junie
+.output.txt
 
-test.json
-test.bson
+# .env file for configuration, e.g. OpenBB
+.env
 
-README2.md
+quantstats.md
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
-.pytest_cache
-.ruff_cache
-htmlcov
 
 # C extensions
 *.so
-
-**/notebooks/test.bson
-**/notebooks/test.json
 
 # Distribution / packaging
 .Python
@@ -54,19 +55,19 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
-#htmlcov/
-#.tox/
-#.nox/
+htmlcov/
+.tox/
+.nox/
 .coverage
-#.coverage.*
-#.cache
-#nosetests.xml
-#coverage.xml
-# *.cover
-# *.py,cover
-# .hypothesis/
-# .pytest_cache/
-# cover/
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -111,20 +112,35 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
+#poetry.toml
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
 #pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -137,8 +153,12 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+.envrc
 .venv
+env/
 venv/
+ENV/
+env.bak/
 venv.bak/
 
 # Spyder project settings
@@ -170,4 +190,35 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+.vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,59 +1,44 @@
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-toml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.12.9'
     hooks:
       - id: ruff
-        args: [ --fix, --exit-non-zero-on-fix ]
+        args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
+
       # Run the formatter
       - id: ruff-format
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.45.0
     hooks:
-      - id: markdownlint-fix
-        args: [ "--ignore", "book/**/*.md" ]
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
-    hooks:
-      - id: pyupgrade
+      - id: markdownlint
+        args: ["--disable", "MD013"]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.2
     hooks:
       - id: check-renovate
-        args: ["--verbose"]
+        args: [ "--verbose" ]
+
       - id: check-github-workflows
         args: ["--verbose"]
-
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
-    hooks:
-        - id: insert-license
-          files: ^(src/cvx)
-          args:
-            ['--license-filepath', 'copyright.txt', '--no-extra-eol']
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:
       - id: actionlint
-        args: [-ignore, SC]
+        args: [ -ignore, SC ]
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1
     hooks:
       - id: validate-pyproject
-
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.35.4
-    hooks:
-      - id: typos

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,29 @@
 # Colors for pretty output
 BLUE := \033[36m
 BOLD := \033[1m
+GREEN := \033[32m
 RESET := \033[0m
 
 .DEFAULT_GOAL := help
 
-.PHONY: help verify install fmt test marimo clean
+.PHONY: build clean book check
 
+install: ## install
+	task build:install
 
-##@ Development Setup
+clean: ## clean
+	task cleanup:clean
 
-venv:
-	@printf "$(BLUE)Creating virtual environment...$(RESET)\n"
-	@curl -LsSf https://astral.sh/uv/install.sh | sh
-	@uv venv --python 3.12
+test: install ## run all tests
+	task docs:test
 
-install: venv ## Install all dependencies using uv
-	@printf "$(BLUE)Installing dependencies...$(RESET)\n"
-	@uv pip install --upgrade pip
-	@uv sync --dev --frozen
+book: test ## compile the companion book
+	task docs:docs
+	task docs:marimushka
+	task docs:book
 
-##@ Code Quality
-
-fmt: venv ## Run code formatting and linting
-	@printf "$(BLUE)Running formatters and linters...$(RESET)\n"
-	@uv pip install pre-commit
-	@uv run pre-commit install
-	@uv run pre-commit run --all-files
-
-##@ Testing
-
-test: install ## Run all tests
-	@printf "$(BLUE)Running tests...$(RESET)\n"
-	@uv pip install pytest
-	@uv run pytest src/tests
-
-##@ Cleanup
-
-clean: ## Clean generated files and directories
-	@printf "$(BLUE)Cleaning project...$(RESET)\n"
-	@git clean -d -X -f
-	@git branch -v | grep "\[gone\]" | cut -f 3 -d ' ' | xargs git branch -D 2>/dev/null || true
-
-##@ Marimo & Jupyter
-
-marimo: install ## Start a Marimo server
-	@printf "$(BLUE)Start Marimo server...$(RESET)\n"
-	@uv pip install marimo
-	@uv run marimo edit book/marimo
-
-
-##@ Help
+check: install ## check the pre-commit hooks, the linting and deptry
+	task quality:check
 
 help: ## Display this help message
 	@printf "$(BOLD)Usage:$(RESET)\n"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,61 @@
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+version: '3'
+
+# Variables
+vars:
+  TESTS_FOLDER: tests
+  MARIMO_FOLDER: book/marimo
+  BOOK_TITLE: '{{.REPO_NAME}}'
+  BOOK_SUBTITLE: 'Documentation and Reports'
+  OPTIONS: ''
+
+# Environment variables
+env:
+  # Colors for pretty output
+  BLUE: '\x1b[36m'
+  GREEN: '\x1b[32m'
+  RED: '\x1b[31m'
+  YELLOW: '\x1b[33m'
+  CYAN: '\x1b[36m'
+  MAGENTA: '\x1b[35m'
+  BOLD: '\x1b[1m'
+  RESET: '\x1b[0m'
+  # Set repository name
+  REPO_NAME:
+    sh: basename $(pwd)
+
+  LOG_INFO: 'printf "${BLUE}[INFO] %s${RESET}\n"'
+  LOG_SUCCESS: 'printf "${GREEN}[SUCCESS] %s${RESET}\n"'
+  LOG_ERROR: 'printf "${RED}[ERROR] %s${RESET}\n"'
+
+# Include task groups
+includes:
+  build:
+    taskfile: ./.github/taskfiles/build.yml
+    desc: Build tasks for managing dependencies and building packages
+  quality:
+    taskfile: ./.github/taskfiles/quality.yml
+    desc: Code quality tasks for formatting, linting, and checking code
+  docs:
+    taskfile: ./.github/taskfiles/docs.yml
+    desc: Documentation tasks for building docs, notebooks, and books
+  cleanup:
+    taskfile: ./.github/taskfiles/cleanup.yml
+    desc: Cleanup tasks for removing generated files and directories
+
+# Task definitions
+tasks:
+  default:
+    desc: Display help information
+    silent: true
+    cmds:
+      - task --list
+
+  help:
+    desc: Display help information with all tasks
+    silent: true
+    cmds:
+      - task --list-all
+        

--- a/book/marimo/demo.py
+++ b/book/marimo/demo.py
@@ -1,3 +1,5 @@
+"""Marimo notebook demonstrating cvxbson functionality for JSON and BSON serialization."""
+
 import marimo
 
 __generated_with = "0.9.27"
@@ -9,13 +11,15 @@ with app.setup:
 
 
 @app.cell
-def __():
+def title():
+    """Display the title of the notebook."""
     mo.md(r"""# cvxbson""")
     return
 
 
 @app.cell
-def __():
+def import_modules():
+    """Import necessary modules for the notebook."""
     from cvx.bson import read_bson, write_bson
     from cvx.json import read_json, write_json
 
@@ -23,25 +27,29 @@ def __():
 
 
 @app.cell
-def __():
+def create_data_header():
+    """Display the header for creating data section."""
     mo.md(r"""## Create a dictionary of numpy arrays""")
     return
 
 
 @app.cell
-def __(np):
+def create_data(np):
+    """Create sample data for demonstration."""
     data = {"A": np.random.rand(50, 50), "B": np.random.rand(50)}
     return (data,)
 
 
 @app.cell
-def __():
+def json_header():
+    """Display the header for JSON section."""
     mo.md(r"""## json""")
     return
 
 
 @app.cell
-def __(data, read_json, write_json):
+def test_json(data, read_json, write_json):
+    """Test JSON serialization and deserialization."""
     write_json("test.json", data)
     _recovered = dict(read_json("test.json"))
     assert np.allclose(data["A"], _recovered["A"])
@@ -50,13 +58,15 @@ def __(data, read_json, write_json):
 
 
 @app.cell
-def __():
+def bson_header():
+    """Display the header for BSON section."""
     mo.md(r"""## bson""")
     return
 
 
 @app.cell
-def __(data, read_bson, write_bson):
+def test_bson(data, read_bson, write_bson):
+    """Test BSON serialization and deserialization."""
     write_bson("test.bson", data)
     _recovered = dict(read_bson("test.bson"))
     assert np.allclose(data["A"], _recovered["A"])

--- a/experiment/demo.py
+++ b/experiment/demo.py
@@ -1,3 +1,9 @@
+"""Demonstration of using dataclasses with BSON serialization.
+
+This module shows how to create a dataclass that can be serialized to and from BSON,
+and how to use it in a strategy pattern.
+"""
+
 from dataclasses import dataclass, field
 
 import polars as pl
@@ -7,6 +13,12 @@ from cvx.bson.dataclass import Data
 
 @dataclass(frozen=True)
 class DataAPI(Data):
+    """Data API class that holds multiple Polars DataFrames.
+
+    This class demonstrates how to create a dataclass that inherits from Data
+    to enable BSON serialization and deserialization.
+    """
+
     # List of tables expected
     A: pl.DataFrame
     B: pl.DataFrame
@@ -39,6 +51,14 @@ if __name__ == "__main__":
     print(data2)
 
     def strategy(api: DataAPI):
+        """Process data using the DataAPI.
+
+        This function demonstrates the strategy pattern where the function
+        receives a data API and doesn't need to know how the data is stored.
+
+        Args:
+            api: The data API containing the required data
+        """
         # the strategy has no idea how the data is stored
         print(api.A)
 

--- a/experiment/demo.py
+++ b/experiment/demo.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Dict
 
 import polars as pl
 
@@ -14,7 +13,7 @@ class DataAPI(Data):
     C: pl.DataFrame
 
     # Define a mutable value for the mapping from short name to full name
-    tables: Dict[str, str] = field(default_factory=lambda: {"A": "AAA", "B": "BBB", "C": "CCC"})
+    tables: dict[str, str] = field(default_factory=lambda: {"A": "AAA", "B": "BBB", "C": "CCC"})
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ dependencies = [
     "numpy>=2",
     "pandas>=2",
     "polars>=1.16.0",
-    "pyarrow>=18.1.0",
-    "typing-extensions>=4.12.2",
+    "pyarrow>=18.1.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,10 @@ repository = "https://github.com/cvxgrp/cvxbson"
 dev = [
     "pytest-cov>=6.0.0",
     "pytest>=8.3.3",
-    "pre-commit>=4.0.1",
- dev-dependencies = [
-     "pytest>=8.3.3",
-     "pre-commit>=4.0.1",
-     "marimo~=0.14.17"
- ]
+    "pre-commit>=4.2.0",
+    "marimo~=0.14.17"
 ]
+
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest>=8.3.3",
     "pre-commit>=4.0.1",
-    "loguru>=0.7.0"
+    "loguru>=0.7.0",
+    "marimo==0.14.17"
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,11 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest>=8.3.3",
     "pre-commit>=4.0.1",
-    "loguru>=0.7.0",
-    "marimo==0.14.17"
+ dev-dependencies = [
+     "pytest>=8.3.3",
+     "pre-commit>=4.0.1",
+     "marimo~=0.14.17"
+ ]
 ]
 
 [tool.ruff]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,79 @@
+# This file is part of the tschm/.config-templates repository
+# (https://github.com/tschm/.config-templates).
+#
+# Maximum line length for the entire project
+line-length = 120
+# Target Python version
+target-version = "py312"
+
+# Exclude directories with Jinja template variables in their names
+exclude = ["**/[{][{]*", "**/*[}][}]*"]
+
+[lint]
+# Available rule sets in Ruff:
+# A: flake8-builtins - Check for python builtins being used as variables or parameters
+# B: flake8-bugbear - Find likely bugs and design problems
+# C4: flake8-comprehensions - Helps write better list/set/dict comprehensions
+# D: pydocstyle - Check docstring style
+# E: pycodestyle errors - PEP 8 style guide
+# ERA: eradicate - Find commented out code
+# F: pyflakes - Detect logical errors
+# I: isort - Sort imports
+# N: pep8-naming - Check PEP 8 naming conventions
+# PT: flake8-pytest-style - Check pytest best practices
+# RUF: Ruff-specific rules
+# S: flake8-bandit - Find security issues
+# SIM: flake8-simplify - Simplify code
+# T10: flake8-debugger - Check for debugger imports and calls
+# UP: pyupgrade - Upgrade syntax for newer Python
+# W: pycodestyle warnings - PEP 8 style guide warnings
+# ANN: flake8-annotations - Type annotation checks
+# ARG: flake8-unused-arguments - Unused arguments
+# BLE: flake8-blind-except - Check for blind except statements
+# COM: flake8-commas - Trailing comma enforcement
+# DTZ: flake8-datetimez - Ensure timezone-aware datetime objects
+# EM: flake8-errmsg - Check error message strings
+# FBT: flake8-boolean-trap - Boolean argument checks
+# ICN: flake8-import-conventions - Import convention enforcement
+# ISC: flake8-implicit-str-concat - Implicit string concatenation
+# NPY: NumPy-specific rules
+# PD: pandas-specific rules
+# PGH: pygrep-hooks - Grep-based checks
+# PIE: flake8-pie - Miscellaneous rules
+# PL: Pylint rules
+# Q: flake8-quotes - Quotation style enforcement
+# RSE: flake8-raise - Raise statement checks
+# RET: flake8-return - Return statement checks
+# SLF: flake8-self - Check for self references
+# TCH: flake8-type-checking - Type checking imports
+# TID: flake8-tidy-imports - Import tidying
+# TRY: flake8-try-except-raise - Try/except/raise checks
+# YTT: flake8-2020 - Python 2020+ compatibility
+
+# Selected rule sets to enforce:
+# D: pydocstyle - Check docstring style
+# E: pycodestyle errors - PEP 8 style guide
+# F: pyflakes - Detect logical errors
+# I: isort - Sort imports
+# N: pep8-naming - Check PEP 8 naming conventions
+# W: pycodestyle warnings - PEP 8 style guide warnings
+# UP: pyupgrade - Upgrade syntax for newer Python
+select = ["D", "E", "F", "I", "N", "W", "UP"]
+
+[lint.pydocstyle]
+convention = "google"
+
+# Formatting configuration
+[format]
+# Use double quotes for strings
+quote-style = "double"
+# Use spaces for indentation
+indent-style = "space"
+# Automatically detect and use the appropriate line ending
+line-ending = "auto"
+
+# File-specific rule exceptions
+[lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]        # Allow assert statements in tests
+"book/marimo/*.py" = ["N803", "S101"] # Allow non-lowercase variable names (N803)
+                                      # and assert statements in marimo files

--- a/src/cvx/bson/__init__.py
+++ b/src/cvx/bson/__init__.py
@@ -11,4 +11,8 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+"""BSON file handling utilities."""
+
 from .file import read_bson, write_bson
+
+__all__ = ["read_bson", "write_bson"]

--- a/src/cvx/bson/dataclass.py
+++ b/src/cvx/bson/dataclass.py
@@ -11,6 +11,8 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+"""Dataclass utilities for BSON serialization and deserialization."""
+
 from dataclasses import dataclass
 from typing import Any
 
@@ -19,17 +21,48 @@ from .file import FILE, read_bson, write_bson
 
 @dataclass(frozen=True)
 class Data:
+    """Base class for dataclasses that can be serialized to and from BSON.
+
+    This class provides methods for serializing to BSON files and deserializing from BSON files.
+    """
+
     def to_bson(self, file: FILE) -> int:
+        """Serialize this object to a BSON file.
+
+        Args:
+            file: Path to the file where the data will be written
+
+        Returns:
+            Number of bytes written
+        """
         return write_bson(file, self.__dict__)
 
     @classmethod
     def from_bson(cls, file: FILE) -> Any:
+        """Create an instance of this class from a BSON file.
+
+        Args:
+            file: Path to the BSON file to read
+
+        Returns:
+            An instance of this class
+        """
         x = read_bson(file)
         return cls(**x)
 
     @classmethod
     def keys(cls):
+        """Get the field names of this dataclass.
+
+        Yields:
+            Field names defined in the class annotations
+        """
         yield from cls.__dict__["__annotations__"].keys()
 
     def items(self):
+        """Get the field names and values of this dataclass instance.
+
+        Yields:
+            Pairs of (field_name, field_value)
+        """
         yield from self.__dict__.items()

--- a/src/cvx/bson/file.py
+++ b/src/cvx/bson/file.py
@@ -11,41 +11,33 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""
-Tools to support working with bson files and strings
-"""
+"""Tools to support working with bson files and strings."""
 
 from __future__ import annotations
 
 from os import PathLike
-from typing import Any, Dict, Union
+from typing import Any
 
 import numpy.typing as npt
 import pandas as pd
-
-# see https://github.com/microsoft/pylance-release/issues/2019
-from typing_extensions import TypeAlias
 
 import bson
 
 from .io import decode, encode
 
-FILE = Union[str, bytes, PathLike]
-MATRIX: TypeAlias = Union[npt.NDArray[Any], pd.DataFrame]
-MATRICES = Dict[str, MATRIX]
+FILE = str | bytes | PathLike
+type MATRIX = npt.NDArray[Any] | pd.DataFrame
+MATRICES = dict[str, MATRIX]
 
 
 def read_bson(file: FILE) -> MATRICES:
-    """
-    Read a bson file and prepare the bson_document needed
+    """Read a bson file and prepare the bson_document needed.
 
     Args:
-        file:
+        file: Path to the BSON file to read
 
     Returns:
         A dictionary of numpy arrays
-
-
     """
     with open(file, mode="rb") as openfile:
         # Reading from bson file
@@ -53,8 +45,7 @@ def read_bson(file: FILE) -> MATRICES:
 
 
 def write_bson(file: FILE, data: MATRICES) -> int:
-    """
-    Write dictionary into a bson file
+    """Write dictionary into a bson file.
 
     Args:
         file: file
@@ -65,8 +56,7 @@ def write_bson(file: FILE, data: MATRICES) -> int:
 
 
 def to_bson(data: MATRICES) -> bytes:
-    """
-    Convert a dictionary of numpy arrays into a bson string
+    """Convert a dictionary of numpy arrays into a bson string.
 
     Args:
         data: dictionary of numpy arrays
@@ -75,5 +65,5 @@ def to_bson(data: MATRICES) -> bytes:
 
 
 def from_bson(bson_str: bytes) -> MATRICES:
-    """Convert a bson string into a dictionary of numpy arrays"""
+    """Convert a bson string into a dictionary of numpy arrays."""
     return {name: decode(value) for name, value in bson.loads(bson_str).items()}

--- a/src/cvx/bson/file.py
+++ b/src/cvx/bson/file.py
@@ -29,7 +29,6 @@ FILE = str | bytes | PathLike
 MATRIX = npt.NDArray[Any] | pd.DataFrame
 MATRICES = dict[str, MATRIX]
 
-
 def read_bson(file: FILE) -> MATRICES:
     """Read a bson file and prepare the bson_document needed.
 

--- a/src/cvx/bson/file.py
+++ b/src/cvx/bson/file.py
@@ -29,6 +29,7 @@ FILE = str | bytes | PathLike
 MATRIX = npt.NDArray[Any] | pd.DataFrame
 MATRICES = dict[str, MATRIX]
 
+
 def read_bson(file: FILE) -> MATRICES:
     """Read a bson file and prepare the bson_document needed.
 

--- a/src/cvx/bson/file.py
+++ b/src/cvx/bson/file.py
@@ -26,7 +26,7 @@ import bson
 from .io import decode, encode
 
 FILE = str | bytes | PathLike
-type MATRIX = npt.NDArray[Any] | pd.DataFrame
+MATRIX = npt.NDArray[Any] | pd.DataFrame
 MATRICES = dict[str, MATRIX]
 
 

--- a/src/cvx/bson/io.py
+++ b/src/cvx/bson/io.py
@@ -11,6 +11,8 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+"""Encoding and decoding utilities for numpy arrays and dataframes in BSON format."""
+
 import json
 from io import BytesIO
 from typing import Any

--- a/src/cvx/bson/io.py
+++ b/src/cvx/bson/io.py
@@ -13,7 +13,7 @@
 #    limitations under the License.
 import json
 from io import BytesIO
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -21,9 +21,8 @@ import polars as pl
 import pyarrow as pa
 
 
-def encode(data: Union[np.ndarray, pd.DataFrame, pl.DataFrame]) -> Any:
-    """
-    Encode a numpy array or a pandas DataFrame
+def encode(data: np.ndarray | pd.DataFrame | pl.DataFrame) -> Any:
+    """Encode a numpy array or a pandas DataFrame.
 
     Args:
         data: The numpy array or pandas DataFrame
@@ -57,9 +56,8 @@ def encode(data: Union[np.ndarray, pd.DataFrame, pl.DataFrame]) -> Any:
     # raise TypeError(f"Invalid Datatype {type(data)}")
 
 
-def decode(data: bytes) -> Union[np.ndarray, pd.DataFrame, pl.DataFrame]:
-    """
-    Decode the bytes back into numpy array or pandas DataFrame
+def decode(data: bytes) -> np.ndarray | pd.DataFrame | pl.DataFrame:
+    """Decode the bytes back into numpy array or pandas DataFrame.
 
     Args:
         data: bytes

--- a/src/cvx/json/__init__.py
+++ b/src/cvx/json/__init__.py
@@ -11,4 +11,8 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+"""JSON file handling utilities."""
+
 from .file import read_json, write_json
+
+__all__ = ["read_json", "write_json"]

--- a/src/cvx/json/file.py
+++ b/src/cvx/json/file.py
@@ -24,7 +24,7 @@ import numpy.typing as npt
 from .numpyencoder import NumpyEncoder
 
 FILE = str | bytes | PathLike
-type MATRIX = npt.NDArray[Any]
+MATRIX = npt.NDArray[Any]
 DATA = dict[str, Any]
 
 

--- a/src/cvx/json/file.py
+++ b/src/cvx/json/file.py
@@ -11,30 +11,34 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""
-Tools to support working with json files
-"""
+"""Tools to support working with json files."""
 
 import json
 from collections.abc import Iterable
 from os import PathLike
-from typing import Any, Dict, Union
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 
-# see https://github.com/microsoft/pylance-release/issues/2019
-from typing_extensions import TypeAlias
-
 from .numpyencoder import NumpyEncoder
 
-FILE = Union[str, bytes, PathLike]
-MATRIX: TypeAlias = npt.NDArray[Any]
-DATA = Dict[str, Any]
+FILE = str | bytes | PathLike
+type MATRIX = npt.NDArray[Any]
+DATA = dict[str, Any]
 
 
 def read_json(json_file: FILE) -> DATA:
-    """Read a json file and return a genaerator of key-value pairs"""
+    """Read a JSON file and convert its contents to a dictionary.
+
+    Iterables in the JSON data are converted to numpy arrays.
+
+    Args:
+        json_file: Path to the JSON file to read
+
+    Returns:
+        A dictionary containing the data from the JSON file
+    """
     with open(json_file) as f:
         json_data = json.load(f)
         d = {}
@@ -48,6 +52,13 @@ def read_json(json_file: FILE) -> DATA:
 
 
 def write_json(json_file: FILE, data: DATA) -> None:
-    """Write a json file with the data"""
+    """Write data to a JSON file.
+
+    Uses NumpyEncoder to handle numpy data types.
+
+    Args:
+        json_file: Path to the JSON file to write
+        data: Dictionary of data to write to the file
+    """
     with open(json_file, "w") as f:
         json.dump(data, f, cls=NumpyEncoder)

--- a/src/cvx/json/numpyencoder.py
+++ b/src/cvx/json/numpyencoder.py
@@ -11,6 +11,12 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+"""JSON encoder for NumPy data types.
+
+This module provides a custom JSON encoder that can handle NumPy data types
+by converting them to standard Python types that can be serialized to JSON.
+"""
+
 import json
 
 import numpy as np
@@ -20,6 +26,15 @@ class NumpyEncoder(json.JSONEncoder):
     """Custom encoder for numpy data types."""
 
     def default(self, obj):
+        """Handle numpy types by converting them to Python standard types.
+
+        Args:
+            obj: The object to encode
+
+        Returns:
+            A JSON serializable version of the object
+        """
+        # Integer types
         if isinstance(
             obj,
             np.int_

--- a/src/cvx/json/numpyencoder.py
+++ b/src/cvx/json/numpyencoder.py
@@ -52,11 +52,11 @@ class NumpyEncoder(json.JSONEncoder):
             return int(obj)
 
         # Float types
-        elif isinstance(obj, (np.float16, np.float32, np.float64)):
+        elif isinstance(obj, np.float16 | np.float32 | np.float64):
             return float(obj)
 
         # Complex types
-        elif isinstance(obj, (np.complex64, np.complex128)):
+        elif isinstance(obj, np.complex64 | np.complex128):
             return {"real": obj.real, "imag": obj.imag}
 
         # Array types

--- a/src/cvx/json/numpyencoder.py
+++ b/src/cvx/json/numpyencoder.py
@@ -37,28 +37,26 @@ class NumpyEncoder(json.JSONEncoder):
         # Integer types
         if isinstance(
             obj,
-            (
-                np.int_,
-                np.intc,
-                np.intp,
-                np.int8,
-                np.int16,
-                np.int32,
-                np.int64,
-                np.uint8,
-                np.uint16,
-                np.uint32,
-                np.uint64,
-            ),
+            np.int_
+            | np.intc
+            | np.intp
+            | np.int8
+            | np.int16
+            | np.int32
+            | np.int64
+            | np.uint8
+            | np.uint16
+            | np.uint32
+            | np.uint64,
         ):
             return int(obj)
 
         # Float types
-        elif isinstance(obj, (np.float16, np.float32, np.float64)):
+        elif isinstance(obj, np.float16 | np.float32 | np.float64):
             return float(obj)
 
         # Complex types
-        elif isinstance(obj, (np.complex64, np.complex128)):
+        elif isinstance(obj, np.complex64 | np.complex128):
             return {"real": obj.real, "imag": obj.imag}
 
         # Array types

--- a/src/cvx/json/numpyencoder.py
+++ b/src/cvx/json/numpyencoder.py
@@ -52,7 +52,7 @@ class NumpyEncoder(json.JSONEncoder):
             return int(obj)
 
         # Float types
-        elif isinstance(obj, np.float16 | np.float32 | np.float64):
+        elif isinstance(obj, (np.float16, np.float32, np.float64)):
             return float(obj)
 
         # Complex types

--- a/src/cvx/json/numpyencoder.py
+++ b/src/cvx/json/numpyencoder.py
@@ -56,7 +56,7 @@ class NumpyEncoder(json.JSONEncoder):
             return float(obj)
 
         # Complex types
-        elif isinstance(obj, np.complex64 | np.complex128):
+        elif isinstance(obj, (np.complex64, np.complex128)):
             return {"real": obj.real, "imag": obj.imag}
 
         # Array types

--- a/src/cvx/json/numpyencoder.py
+++ b/src/cvx/json/numpyencoder.py
@@ -37,33 +37,41 @@ class NumpyEncoder(json.JSONEncoder):
         # Integer types
         if isinstance(
             obj,
-            np.int_
-            | np.intc
-            | np.intp
-            | np.int8
-            | np.int16
-            | np.int32
-            | np.int64
-            | np.uint8
-            | np.uint16
-            | np.uint32
-            | np.uint64,
+            (
+                np.int_,
+                np.intc,
+                np.intp,
+                np.int8,
+                np.int16,
+                np.int32,
+                np.int64,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint64,
+            ),
         ):
             return int(obj)
 
-        elif isinstance(obj, np.float16 | np.float32 | np.float64):
+        # Float types
+        elif isinstance(obj, (np.float16, np.float32, np.float64)):
             return float(obj)
 
-        elif isinstance(obj, np.complex64 | np.complex128):
+        # Complex types
+        elif isinstance(obj, (np.complex64, np.complex128)):
             return {"real": obj.real, "imag": obj.imag}
 
+        # Array types
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
 
+        # Boolean types
         elif isinstance(obj, np.bool_):
             return bool(obj)
 
+        # Void type
         elif isinstance(obj, np.void):
             return None
 
+        # Fall back to the default encoder
         return json.JSONEncoder.default(self, obj)

--- a/src/cvx/json/numpyencoder.py
+++ b/src/cvx/json/numpyencoder.py
@@ -17,34 +17,32 @@ import numpy as np
 
 
 class NumpyEncoder(json.JSONEncoder):
-    """Custom encoder for numpy data types"""
+    """Custom encoder for numpy data types."""
 
     def default(self, obj):
         if isinstance(
             obj,
-            (
-                np.int_,
-                np.intc,
-                np.intp,
-                np.int8,
-                np.int16,
-                np.int32,
-                np.int64,
-                np.uint8,
-                np.uint16,
-                np.uint32,
-                np.uint64,
-            ),
+            np.int_
+            | np.intc
+            | np.intp
+            | np.int8
+            | np.int16
+            | np.int32
+            | np.int64
+            | np.uint8
+            | np.uint16
+            | np.uint32
+            | np.uint64,
         ):
             return int(obj)
 
-        elif isinstance(obj, (np.float16, np.float32, np.float64)):
+        elif isinstance(obj, np.float16 | np.float32 | np.float64):
             return float(obj)
 
-        elif isinstance(obj, (np.complex64, np.complex128)):
+        elif isinstance(obj, np.complex64 | np.complex128):
             return {"real": obj.real, "imag": obj.imag}
 
-        elif isinstance(obj, (np.ndarray,)):
+        elif isinstance(obj, np.ndarray):
             return obj.tolist()
 
         elif isinstance(obj, np.bool_):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""fixtures"""
+"""fixtures."""
 
 from pathlib import Path
 
@@ -7,5 +7,5 @@ import pytest
 
 @pytest.fixture(scope="session", name="resource_dir")
 def resource_fixture():
-    """resource fixture"""
+    """Resource fixture."""
     return Path(__file__).parent / "resources"

--- a/tests/test_bson.py
+++ b/tests/test_bson.py
@@ -1,3 +1,9 @@
+"""Tests for BSON serialization and deserialization functionality.
+
+This module tests the core BSON file operations including reading, writing,
+and direct conversion between Python objects and BSON.
+"""
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_bson.py
+++ b/tests/test_bson.py
@@ -8,8 +8,7 @@ from cvx.bson.file import from_bson, read_bson, to_bson, write_bson
 
 @pytest.mark.parametrize("shape", [(50, 50), (1000, 50), (50, 1000), (1000, 1000), (5000, 2000)])
 def test_write(tmp_path, shape):
-    """
-    Test that a numpy array is written and read correctly
+    """Test that a numpy array is written and read correctly.
 
     Args:
         tmp_path: temporary path fixture
@@ -25,8 +24,7 @@ def test_write(tmp_path, shape):
 
 
 def test_vector(tmp_path):
-    """
-    Test that a vector is written and read correctly
+    """Test that a vector is written and read correctly.
 
     Args:
         tmp_path: temporary path fixture
@@ -42,8 +40,7 @@ def test_vector(tmp_path):
 
 @pytest.mark.parametrize("shape", [(50, 50), (1000, 50), (50, 1000), (1000, 1000), (5000, 2000)])
 def test_without_file(shape):
-    """
-    Test that a matrix is written and read correctly
+    """Test that a matrix is written and read correctly.
 
     Args:
         shape: shape of the matrix

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -1,3 +1,9 @@
+"""Tests for dataclass serialization and deserialization with BSON.
+
+This module tests the functionality of the Data base class for dataclasses,
+including serialization to BSON, deserialization from BSON, and data access patterns.
+"""
+
 from dataclasses import dataclass
 
 import numpy as np
@@ -9,6 +15,11 @@ from cvx.bson.dataclass import Data
 
 @dataclass(frozen=True)
 class Maffay(Data):
+    """Test dataclass for BSON serialization.
+
+    This class demonstrates a dataclass that can be serialized to and from BSON.
+    """
+
     x: pd.DataFrame
     y: pl.DataFrame
     z: np.array
@@ -16,16 +27,36 @@ class Maffay(Data):
 
 @dataclass(frozen=True)
 class DataAPI(Data):
+    """Test data API class for BSON serialization.
+
+    This class demonstrates a dataclass with custom methods that can be
+    serialized to and from BSON.
+    """
+
     # you need to explicitly declare the tables expected
     x: pd.DataFrame
     y: pl.DataFrame
     z: np.array
 
     def items(self):
+        """Get the field names and values of this dataclass instance.
+
+        Yields:
+            Pairs of (field_name, field_value)
+        """
         yield from self.__dict__.items()
 
 
 def assert_equal(obj1, obj2):
+    """Assert that two objects are equal, handling different data types.
+
+    This function compares different types of objects (pandas DataFrames,
+    numpy arrays, polars DataFrames) using the appropriate equality check.
+
+    Args:
+        obj1: First object to compare
+        obj2: Second object to compare
+    """
     assert type(obj1) is type(obj2)
 
     if isinstance(obj1, pd.DataFrame):
@@ -39,6 +70,14 @@ def assert_equal(obj1, obj2):
 
 
 def test_conversion(tmp_path):
+    """Test conversion of a dataclass to and from BSON.
+
+    This test creates a dataclass instance, serializes it to BSON,
+    and then deserializes it back.
+
+    Args:
+        tmp_path: Temporary path fixture
+    """
     matrix = np.random.rand(5, 2)
 
     x = pd.DataFrame(data=matrix)
@@ -52,6 +91,15 @@ def test_conversion(tmp_path):
 
 
 def test_reflection(tmp_path):
+    """Test reflection of data through a dataclass.
+
+    This test creates a dictionary of data, filters it based on the
+    dataclass fields, creates a dataclass instance, and then verifies
+    that the data is preserved.
+
+    Args:
+        tmp_path: Temporary path fixture
+    """
     matrix = np.random.rand(5, 2)
 
     x = pd.DataFrame(data=matrix)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,136 @@
+"""Tests for validating code examples in the project documentation.
+
+This file is part of the tschm/.config-templates repository
+(https://github.com/tschm/.config-templates).
+
+
+This module contains tests that extract Python code blocks from the README.md file
+and run them through doctest to ensure they are valid and working as expected.
+This helps maintain accurate and working examples in the documentation.
+"""
+
+import doctest
+import os
+import re
+import warnings
+from pathlib import Path
+
+import pytest
+from _pytest.capture import CaptureFixture
+
+
+def find_project_root(start_path: Path = None) -> Path:
+    """Find the project root directory by looking for the .git folder.
+
+    This function iterates up the directory tree from the given starting path
+    until it finds a directory containing a .git folder, which is assumed to be
+    the project root.
+
+    Args:
+        start_path (Path, optional): The path to start searching from.
+            If None, uses the directory of the file calling this function.
+
+    Returns:
+        Path: The path to the project root directory.
+
+    Raises:
+        FileNotFoundError: If no .git directory is found in any parent directory.
+    """
+    if start_path is None:
+        # If no start_path is provided, use the current file's directory
+        start_path = Path(__file__).parent
+
+    # Convert to absolute path to handle relative paths
+    current_path = start_path.absolute()
+
+    # Iterate up the directory tree
+    while current_path != current_path.parent:  # Stop at the root directory
+        # Check if .git directory exists
+        git_dir = current_path / ".git"
+        if git_dir.exists() and git_dir.is_dir():
+            return current_path
+
+        # Move up to the parent directory
+        current_path = current_path.parent
+
+    # If we've reached the root directory without finding .git
+    raise FileNotFoundError("Could not find project root: no .git directory found in any parent directory")
+
+
+@pytest.fixture
+def project_root() -> Path:
+    """Fixture that provides the project root directory.
+
+    Returns:
+        Path: The path to the project root directory.
+    """
+    return find_project_root(Path(__file__).parent)
+
+
+@pytest.fixture()
+def docstring(project_root: Path) -> str:
+    """Extract Python code blocks from README.md and prepare them for doctest.
+
+    This fixture reads the README.md file, extracts all Python code blocks
+    (enclosed in triple backticks with 'python' language identifier), and
+    combines them into a single docstring that can be processed by doctest.
+
+    Args:
+        project_root: Path to the project root directory
+
+    Returns:
+        str: A docstring containing all Python code examples from README.md
+
+    """
+    # Read the README.md file
+    try:
+        with open(project_root / "README.md", encoding="utf-8") as f:
+            content = f.read()
+
+            # Extract Python code blocks (assuming they are in triple backticks)
+            blocks = re.findall(r"```python(.*?)```", content, re.DOTALL)
+
+            code = "\n".join(blocks).strip()
+
+            # Add a docstring wrapper for doctest to process the code
+            docstring = f"\n{code}\n"
+
+            return docstring
+
+    except FileNotFoundError:
+        warnings.warn("README.md file not found")
+        return ""
+
+
+def test_blocks(project_root: Path, docstring: str, capfd: CaptureFixture[str]) -> None:
+    """Test that all Python code blocks in README.md execute without errors.
+
+    This test runs all the Python code examples from the README.md file
+    through doctest to ensure they execute correctly. It captures any
+    output or errors and fails the test if any issues are detected.
+
+    Args:
+        project_root: Path to the project root directory
+        docstring: String containing all Python code examples from README.md
+        capfd: Pytest fixture for capturing stdout/stderr output
+
+    Raises:
+        pytest.fail: If any doctest fails or produces unexpected output
+
+    """
+    # Change to the root directory to ensure imports work correctly
+    os.chdir(project_root)
+
+    try:
+        # Run the code examples through doctest
+        doctest.run_docstring_examples(docstring, globals())
+    except doctest.DocTestFailure as e:
+        # If a DocTestFailure occurs, capture it and manually fail the test
+        pytest.fail(f"Doctests failed: {e}")
+
+    # Capture the output after running doctests
+    captured = capfd.readouterr()
+
+    # If there is any output (error message), fail the test
+    if captured.out:
+        pytest.fail(f"Doctests failed with the following output:\n{captured.out} and \n{docstring}")

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -1,3 +1,9 @@
+"""Tests for encoding and decoding different data types.
+
+This module tests the encode and decode functions for different data types
+including Polars DataFrames, Pandas DataFrames, and NumPy arrays.
+"""
+
 import numpy as np
 import pandas as pd
 import polars as pl
@@ -6,18 +12,33 @@ from cvx.bson.io import decode, encode
 
 
 def test_pl():
+    """Test encoding and decoding of Polars DataFrames.
+
+    This test creates a Polars DataFrame, encodes it, decodes it,
+    and verifies that the original and decoded DataFrames are equal.
+    """
     frame = pl.DataFrame(data=np.random.rand(10, 5))
     b = decode(encode(frame))
     assert frame.equals(b)
 
 
 def test_pd():
+    """Test encoding and decoding of Pandas DataFrames.
+
+    This test creates a Pandas DataFrame, encodes it, decodes it,
+    and verifies that the original and decoded DataFrames are equal.
+    """
     frame = pd.DataFrame(data=np.random.rand(10, 5))
     b = decode(encode(frame))
     pd.testing.assert_frame_equal(b, frame)
 
 
 def test_np():
+    """Test encoding and decoding of NumPy arrays.
+
+    This test creates a NumPy array, encodes it, decodes it,
+    and verifies that the original and decoded arrays are equal.
+    """
     matrix = np.random.rand(10, 5)
     b = decode(encode(matrix))
     np.testing.assert_array_equal(matrix, b)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,3 +1,9 @@
+"""Tests for JSON serialization and deserialization functionality.
+
+This module tests the core JSON file operations including reading and writing
+different data types including NumPy arrays and primitive types.
+"""
+
 import numpy as np
 import pytest
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -6,8 +6,7 @@ from cvx.json import read_json, write_json
 
 @pytest.mark.parametrize("shape", [(50, 50), (1000, 50), (50, 1000), (1000, 1000), (5000, 2000)])
 def test_read_and_write_json(tmp_path, shape):
-    """
-    Test that a numpy array is written and read correctly
+    """Test that a numpy array is written and read correctly.
 
     Args:
         tmp_path: temporary path fixture

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,3 +1,9 @@
+"""Tests for pandas and polars DataFrame serialization with BSON.
+
+This module tests the serialization and deserialization of pandas and polars
+DataFrames using the BSON format.
+"""
+
 import numpy as np
 import pandas as pd
 import polars as pl
@@ -8,6 +14,15 @@ from cvx.bson.file import from_bson, to_bson
 
 @pytest.fixture()
 def data():
+    """Provide test data for serialization tests.
+
+    Returns:
+        A dictionary containing various data types to test serialization:
+        - pandas DataFrame
+        - numpy array
+        - pandas DataFrame with timestamp index
+        - polars DataFrame
+    """
     return {
         "frame": pd.DataFrame(data=np.random.rand(5, 2)),
         "numpy": np.random.rand(5, 2),
@@ -20,6 +35,15 @@ def data():
 
 
 def assert_equal(obj1, obj2):
+    """Assert that two objects are equal, handling different data types.
+
+    This function compares different types of objects (pandas DataFrames,
+    numpy arrays, polars DataFrames) using the appropriate equality check.
+
+    Args:
+        obj1: First object to compare
+        obj2: Second object to compare
+    """
     assert type(obj1) is type(obj2)
 
     if isinstance(obj1, pd.DataFrame):
@@ -44,6 +68,15 @@ def test_roundtrip(data):
 
 
 def test_file(data, tmp_path):
+    """Test serialization and deserialization using file I/O.
+
+    This test writes data to a BSON file, reads it back, and verifies
+    that the deserialized data matches the original data.
+
+    Args:
+        data: Test data fixture
+        tmp_path: Temporary path fixture
+    """
     with open(file=tmp_path / "xxx.bson", mode="wb") as bson_file:
         bson_file.write(to_bson(data))
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -33,8 +33,7 @@ def assert_equal(obj1, obj2):
 
 
 def test_roundtrip(data):
-    """
-    Testing the roundtrip
+    """Testing the roundtrip.
 
     Args:
         data: Fixture exposing a dictionary of data

--- a/tests/test_taskfile.py
+++ b/tests/test_taskfile.py
@@ -35,7 +35,6 @@ class Result:
         return stdout
 
     @property
-    @property
     def stderr(self):
         """Get the standard error of the process.
 

--- a/tests/test_taskfile.py
+++ b/tests/test_taskfile.py
@@ -35,13 +35,17 @@ class Result:
         return stdout
 
     @property
+    @property
     def stderr(self):
         """Get the standard error of the process.
 
         Returns:
             The standard error output
         """
-        return self.result.stderr
+        stderr = self.result.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        return stderr
 
     @property
     def returncode(self):

--- a/tests/test_taskfile.py
+++ b/tests/test_taskfile.py
@@ -1,0 +1,500 @@
+"""Tests for the Taskfile.yml tasks and functionality.
+
+This module contains tests that verify all tasks defined in Taskfile.yml
+work correctly and produce the expected output.
+"""
+
+import dataclasses
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+
+@dataclasses.dataclass
+class Result:
+    """Class for storing the result of a task."""
+
+    result: CompletedProcess
+
+    @property
+    def stdout(self):
+        """Get the standard output of the process.
+
+        Returns:
+            The standard output as a string, decoded if necessary
+        """
+        stdout = self.result.stdout
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+
+        return stdout
+
+    @property
+    def stderr(self):
+        """Get the standard error of the process.
+
+        Returns:
+            The standard error output
+        """
+        return self.result.stderr
+
+    @property
+    def returncode(self):
+        """Get the return code of the process.
+
+        Returns:
+            The process return code
+        """
+        return self.result.returncode
+
+    def contains_message(self, message: str) -> bool:
+        """Check if a message is in stdout.
+
+        Args:
+            message: The message to check for
+
+        Returns:
+            True if the message is in stdout, False otherwise
+        """
+        return message in self.stdout
+
+
+class TestTaskfile:
+    """Tests for tasks defined in Taskfile.yml."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Setup before each test and teardown after.
+
+        This ensures tests don't interfere with each other.
+        """
+        # Store original working directory
+        self.original_dir = os.getcwd()
+
+        # Create a temporary directory for testing
+        self.temp_dir = tempfile.mkdtemp()
+
+        # Copy Taskfile.yml to temp directory
+        shutil.copy(os.path.join(self.original_dir, "Taskfile.yml"), self.temp_dir)
+
+        # Copy .github directory to temp directory if it exists
+        github_dir = os.path.join(self.original_dir, ".github")
+        if os.path.exists(github_dir):
+            dest_github_dir = os.path.join(self.temp_dir, ".github")
+            os.makedirs(dest_github_dir, exist_ok=True)
+
+            # Copy taskfiles directory
+            taskfiles_dir = os.path.join(github_dir, "taskfiles")
+            if os.path.exists(taskfiles_dir):
+                dest_taskfiles_dir = os.path.join(dest_github_dir, "taskfiles")
+                os.makedirs(dest_taskfiles_dir, exist_ok=True)
+                for file in os.listdir(taskfiles_dir):
+                    if file.endswith(".yml"):
+                        shutil.copy(os.path.join(taskfiles_dir, file), os.path.join(dest_taskfiles_dir, file))
+
+        # Copy taskfiles directory to temp directory (for backward compatibility)
+        if os.path.exists(os.path.join(self.original_dir, "taskfiles")):
+            taskfiles_dir = os.path.join(self.temp_dir, "taskfiles")
+            os.makedirs(taskfiles_dir, exist_ok=True)
+            for file in os.listdir(os.path.join(self.original_dir, "taskfiles")):
+                if file.endswith(".yml"):
+                    shutil.copy(os.path.join(self.original_dir, "taskfiles", file), os.path.join(taskfiles_dir, file))
+
+        # Change to temp directory
+        os.chdir(self.temp_dir)
+
+        # Run the test
+        yield
+
+        # Change back to original directory
+        os.chdir(self.original_dir)
+
+        # Clean up temp directory
+        shutil.rmtree(self.temp_dir)
+
+    def create_file(self, path, content):
+        """Create a file with the given content.
+
+        Args:
+            path: Path to the file
+            content: Content to write to the file
+        """
+        # Create parent directories if they don't exist
+        parent_dir = os.path.dirname(path)
+        if parent_dir and not os.path.exists(parent_dir):
+            os.makedirs(parent_dir, exist_ok=True)
+
+        # Write the file
+        with open(path, "w") as f:
+            f.write(content)
+
+    def create_pyproject_toml(self):
+        """Create a minimal pyproject.toml file."""
+        self.create_file("pyproject.toml", "[project]\nname = 'test'\nversion = '0.1.0'\n")
+
+    def create_src_structure(self):
+        """Create a minimal src directory structure."""
+        os.makedirs("src/test_module", exist_ok=True)
+        self.create_file("src/test_module/__init__.py", "# Test module\n")
+
+    def create_tests_structure(self):
+        """Create a minimal tests directory structure."""
+        os.makedirs("tests", exist_ok=True)
+        self.create_file("tests/test_dummy.py", "def test_dummy():\n    assert True\n")
+
+    def create_marimo_structure(self):
+        """Create a minimal marimo directory structure."""
+        os.makedirs("book/marimo", exist_ok=True)
+        self.create_file("book/marimo/test.py", "# Test notebook\n")
+
+    def get_task_name(self, base_name):
+        """Get the task name with the appropriate group prefix.
+
+        This function handles the transition from flat task names to grouped task names.
+        It tries to map base task names to their group prefixed versions.
+
+        Args:
+            base_name: The base task name without group prefix
+
+        Returns:
+            The task name with appropriate group prefix
+        """
+        # Map of base task names to their group prefixed versions
+        task_map = {
+            "uv": "build:uv",
+            "install": "build:install",
+            "build": "build:build",
+            "fmt": "quality:fmt",
+            "lint": "quality:lint",
+            "deptry": "quality:deptry",
+            "check": "quality:check",
+            "test": "docs:test",
+            "docs": "docs:docs",
+            "marimushka": "docs:marimushka",
+            "book": "docs:book",
+            "marimo": "docs:marimo",
+            "clean": "cleanup:clean",
+        }
+
+        # If the task name already has a group prefix, is empty, or starts with --, return it as is
+        if ":" in base_name or base_name == "" or base_name.startswith("--"):
+            return base_name
+
+        # Handle special case for help task
+        if base_name == "help":
+            return "--list-all"
+
+        # Return the mapped task name if it exists, otherwise return the original
+        return task_map.get(base_name, base_name)
+
+    def run_task(self, task_name, check=True, timeout=30):
+        """Run a task and return the process result.
+
+        Args:
+            task_name: Name of the task to run
+            check: Whether to check for successful exit code
+            timeout: Maximum time to wait for task completion
+
+        Returns:
+            Result instance containing the process result
+        """
+        # Get the appropriate task name with group prefix if needed
+        task_name = self.get_task_name(task_name)
+
+        try:
+            result = Result(
+                result=subprocess.run(
+                    f"task {task_name}", shell=True, capture_output=True, text=True, check=check, timeout=timeout
+                )
+            )
+            return result
+        except subprocess.TimeoutExpired as e:
+            # For tasks that might hang (like servers)
+            completed_process = subprocess.CompletedProcess(
+                args=e.cmd,
+                returncode=0,  # Assume it's working if it's still running
+                stdout=e.stdout if e.stdout else "Task is still running (timeout)",
+                stderr=e.stderr if e.stderr else "",
+            )
+            return Result(result=completed_process)
+
+    def test_default_task(self):
+        """Test that the default task runs and displays help."""
+        result = self.run_task("")
+        assert result.returncode == 0, f"Default task failed with: {result.stderr}"
+        assert result.contains_message("Available tasks"), "Help information not displayed"
+        # Check that it lists at least some common tasks
+        assert result.contains_message("* docs:book:") or result.contains_message("* book:"), "Book task not listed"
+        assert result.contains_message("* docs:test:") or result.contains_message("* test:"), "Test task not listed"
+
+    def test_help_task(self):
+        """Test that the help task runs and displays help."""
+        # The help task should run 'task --list-all'
+        result = self.run_task("help")
+        assert result.returncode == 0, f"Help task failed with: {result.stderr}"
+        assert result.contains_message("Available tasks"), "Help information not displayed"
+
+    def test_install_task(self):
+        """Test that the install task creates a virtual environment."""
+        # We're in a temp directory, so .venv shouldn't exist yet
+        assert not Path(".venv").exists(), "Virtual environment already exists"
+
+        # Create a mock pyproject.toml to test both paths
+        self.create_pyproject_toml()
+
+        result = self.run_task("build:install", check=False)
+
+        # Check for expected output - either it's creating a new environment
+        # or it's skipping because one already exists (in the test environment)
+        assert result.contains_message("Creating virtual environment...") or result.contains_message(
+            "Virtual environment already exists"
+        ), f"Unexpected output: {result.stdout}"
+
+        # The second part of the test is problematic because the task might detect
+        # a virtual environment even in a new directory (due to global settings or parent directories)
+        # So we'll just check that the install task runs without errors
+
+        # Test without pyproject.toml
+        os.remove("pyproject.toml")
+        result = self.run_task("build:install", check=False)
+
+        # Check that the task runs without errors and produces some output
+        assert result.returncode == 0, f"Install task failed with: {result.stderr}"
+        assert result.stdout, "Install task produced no output"
+
+        # Change back to the temp directory for other tests
+        os.chdir(self.temp_dir)
+
+    def test_build_task(self):
+        """Test that the build task builds the package."""
+        # Create a mock pyproject.toml
+        self.create_pyproject_toml()
+
+        # Since the build task depends on install, we need to check for either
+        # the build message or install-related messages
+        result = self.run_task("build", check=False)
+        expected_msgs = [
+            "Building package...",
+            "Creating virtual environment...",
+            "Virtual environment already exists",
+            "Installing dependencies",
+        ]
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Expected build or install message not found in output: {result.stdout}"
+        )
+
+        # Test without pyproject.toml
+        os.remove("pyproject.toml")
+        result = self.run_task("build", check=False)
+        expected_msgs = ["No pyproject.toml found", "skipping build"]
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Should warn about missing pyproject.toml: {result.stdout}"
+        )
+
+    def test_fmt_task(self):
+        """Test that the fmt task runs formatters."""
+        result = self.run_task("fmt", check=False)
+        assert result.contains_message("Running formatters..."), (
+            f"Formatter message not found in output: {result.stdout}"
+        )
+
+    def test_lint_task(self):
+        """Test that the lint task runs linters."""
+        result = self.run_task("lint", check=False)
+        assert result.contains_message("Running linters..."), f"Linter message not found in output: {result.stdout}"
+
+    def test_deptry_task(self):
+        """Test that the deptry task checks dependencies."""
+        # Create a mock pyproject.toml
+        self.create_pyproject_toml()
+
+        result = self.run_task("deptry", check=False)
+        assert result.contains_message("Running deptry..."), f"Deptry message not found in output: {result.stdout}"
+
+        # Test without pyproject.toml
+        os.remove("pyproject.toml")
+        result = self.run_task("deptry", check=False)
+        assert result.contains_message("No pyproject.toml found"), (
+            f"Should warn about missing pyproject.toml: {result.stdout}"
+        )
+
+    def test_check_task(self):
+        """Test that the check task runs all checks."""
+        # This is a meta-task that runs other tasks
+        result = self.run_task("check", check=False)
+        # We don't expect this to pass necessarily, just to run
+        # Check for any of the expected messages from the dependent tasks
+        expected_msgs = [
+            "All checks passed",
+            "Running formatters",
+            "Running linters",
+            "Running deptry",
+            "No pyproject.toml found",
+        ]
+        assert result.returncode == 0 or any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Check task failed: {result.stderr}"
+        )
+
+    def test_test_task(self):
+        """Test that the test task runs tests."""
+        # Create a minimal test directory structure
+        self.create_tests_structure()
+
+        result = self.run_task("docs:test", check=False)
+        assert result.contains_message("Running tests..."), f"Test message not found in output: {result.stdout}"
+
+        # Test with no source folder
+        result = self.run_task("docs:test", check=False)
+        assert result.contains_message("No valid source folder structure found") or result.contains_message(
+            "Running tests..."
+        ), f"Unexpected output: {result.stdout}"
+
+    def test_docs_task(self):
+        """Test that the docs task builds documentation."""
+        # Create a mock pyproject.toml and src structure
+        self.create_pyproject_toml()
+        self.create_src_structure()
+
+        # Since the docs task depends on install, we need to check for either
+        # the docs message or install-related messages
+        result = self.run_task("docs", check=False)
+        expected_msgs = [
+            "Building documentation...",
+            "Creating virtual environment...",
+            "Virtual environment already exists",
+            "Installing dependencies",
+        ]
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Expected docs or install message not found in output: {result.stdout}"
+        )
+
+        # Test without pyproject.toml
+        os.remove("pyproject.toml")
+        result = self.run_task("docs", check=False)
+        expected_msgs = ["No pyproject.toml found", "skipping docs"]
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Should warn about missing pyproject.toml: {result.stdout}"
+        )
+
+    def test_marimushka_task(self):
+        """Test that the marimushka task exports notebooks."""
+        result = self.run_task("marimushka", check=False)
+        assert result.contains_message("Exporting notebooks from"), (
+            f"Marimushka message not found in output: {result.stdout}"
+        )
+
+        # Create marimo directory and test file
+        self.create_marimo_structure()
+
+        result = self.run_task("marimushka", check=False)
+        assert result.contains_message("Exporting notebooks from"), (
+            f"Marimushka message not found in output: {result.stdout}"
+        )
+
+    def test_book_task(self):
+        """Test that the book task builds the companion book."""
+        # Create necessary directory structure
+        self.create_tests_structure()
+        self.create_src_structure()
+        self.create_marimo_structure()
+        self.create_pyproject_toml()
+
+        # Since the book task depends on test, docs, and marimushka, we need to check for
+        # messages from any of these tasks or their dependencies
+        result = self.run_task("book", check=False)
+        expected_msgs = [
+            "Building combined documentation...",
+            "Running tests...",
+            "Building documentation...",
+            "Exporting notebooks...",
+            "Creating virtual environment...",
+            "Virtual environment already exists",
+            "Installing dependencies",
+        ]
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Expected book-related message not found in output: {result.stdout}"
+        )
+
+    def test_marimo_task(self):
+        """Test that the marimo task starts a server."""
+        # Create marimo directory
+        self.create_marimo_structure()
+
+        # Use a very short timeout to avoid actually starting the server
+        result = self.run_task("marimo", check=False, timeout=1)
+
+        expected_msgs = ["Start Marimo server with", "Marimo folder", "Installing dependencies"]
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Marimo server message not found in output: {result.stdout}"
+        )
+
+    def test_clean_task(self):
+        """Test that the clean task cleans the project."""
+        # Create some files that would be cleaned
+        os.makedirs("dist", exist_ok=True)
+        os.makedirs("build", exist_ok=True)
+        os.makedirs(".pytest_cache", exist_ok=True)
+
+        # Just check that the task runs and outputs the expected message
+        # We don't actually want to run the full clean in tests
+        result = self.run_task("clean", check=False)
+
+        # The task might actually clean files or just show the message
+        expected_msgs = ["Cleaning project...", "git clean", "Removing local branches..."]
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Clean message not found in output: {result.stdout}"
+        )
+
+    def test_all_tasks_defined(self):
+        """Test that all tasks defined in Taskfile.yml are tested."""
+        # Get list of all tasks from task --list-all to include tasks from included taskfiles
+        result = self.run_task("--list-all")
+
+        # Extract task names from output
+        task_lines = [line.strip() for line in result.stdout.split("\n") if line.strip()]
+        task_names = []
+
+        # Known group names to skip
+        group_names = ["build", "quality", "docs", "cleanup"]
+
+        for line in task_lines:
+            # Skip lines that don't look like task definitions
+            if "*" not in line:
+                continue
+
+            # Extract task name (after the * and before the colon)
+            parts = line.split(":", 1)
+            if len(parts) < 2:
+                continue
+
+            task_part = parts[0].strip()
+            if "*" in task_part:
+                task_name = task_part.split("*", 1)[1].strip()
+
+                # Skip default, help tasks, and group names as they're tested separately or not tasks
+                if task_name in ["default", "help"] or task_name in group_names:
+                    continue
+
+                # For grouped tasks, extract the base task name (after the colon)
+                if ":" in task_name:
+                    group, base_task = task_name.split(":", 1)
+                    task_names.append(base_task)
+                else:
+                    task_names.append(task_name)
+
+        # Special case mapping for tasks with different test method names
+        task_method_map = {
+            "cleanup": "clean",  # test_clean_task tests the cleanup task
+        }
+
+        # Check that we have a test for each task
+        for task in task_names:
+            # Map task name to test method name if needed
+            test_task = task_method_map.get(task, task)
+            test_method = f"test_{test_task}_task"
+            assert hasattr(self, test_method), f"Missing test for task '{task}' (looking for {test_method})"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,21 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
+]
+
+[[package]]
 name = "bson"
 version = "0.5.10"
 source = { registry = "https://pypi.org/simple" }
@@ -24,6 +39,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]
@@ -142,6 +169,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "loguru" },
+    { name = "marimo" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -151,6 +179,7 @@ dev = [
 requires-dist = [
     { name = "bson", specifier = ">=0.5.10" },
     { name = "loguru", marker = "extra == 'dev'", specifier = ">=0.7.0" },
+    { name = "marimo", marker = "extra == 'dev'", specifier = "==0.14.17" },
     { name = "numpy", specifier = ">=2" },
     { name = "pandas", specifier = ">=2" },
     { name = "polars", specifier = ">=1.16.0" },
@@ -169,6 +198,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/86/5b41c32ecedcfdb4c77b28b6cb14234f252075f8cdb254531727a35547dd/docutils-0.22.tar.gz", hash = "sha256:ba9d57750e92331ebe7c08a1bbf7a7f8143b86c476acd51528b042216a6aad0f", size = 2277984, upload-time = "2025-07-29T15:20:31.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/57/8db39bc5f98f042e0153b1de9fb88e1a409a33cda4dd7f723c2ed71e01f6/docutils-0.22-py3-none-any.whl", hash = "sha256:4ed966a0e96a0477d852f7af31bdcb3adc049fbb35ccba358c2ea8a03287615e", size = 630709, upload-time = "2025-07-29T15:20:28.335Z" },
 ]
 
 [[package]]
@@ -193,6 +231,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.13"
 source = { registry = "https://pypi.org/simple" }
@@ -202,12 +249,42 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
 ]
 
 [[package]]
@@ -221,6 +298,150 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "loro"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/56/755b0cde1197884a601420fb6353f3dc0558de66adfd43dc00753b5e6c38/loro-1.5.4.tar.gz", hash = "sha256:bc2d522e4c02922cad65ef5df6dd4e1fe55ddfad3ae7b5f1754f356ccf42f639", size = 63610, upload-time = "2025-08-14T14:11:39.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/cb/0072935450c9f822bc39261cf8d4263d3f7b895a25a65daa8ce7970e853e/loro-1.5.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2cbc84f8c4e7f48d1648534bc44da0e26104c12038a8738bc58f64381c408855", size = 3108907, upload-time = "2025-08-14T08:58:04.048Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/34/1fb8634f3be0b3d7fafdd47e38cf303b6d9e14884a3a9fc8860f15a37d0d/loro-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:11bb586b77dd4b1d755469ec31cc0dcc524f4364e243a405ecdd5dd2c884354e", size = 2910714, upload-time = "2025-08-14T08:57:37.496Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/9e/5d2339179f102dbb014cf651a0750270e6dd7b92c2637e2a26358b70814b/loro-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fbe82b9709a01756701827d7917072a97579130c738d6bae489b930d35528426", size = 3125311, upload-time = "2025-08-14T08:50:44.137Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/59/ac1d7f2048cc895fa35d9f3fc69a6848ec1e4432b0c3fd7297800a0f41c1/loro-1.5.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0f14b292f804382bdb91ef6185ba77be376d190c438179fcc2e207793b99ab46", size = 3184178, upload-time = "2025-08-14T08:51:50.291Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/177a13d9fcf894f7730677296f7c1c0cba4763a5badd99b6c0ec37248bcb/loro-1.5.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:18f03731cc2fb425f4af37f5ef232246747dabdb8b47f85eea6b83d06f5551ad", size = 3580600, upload-time = "2025-08-14T08:52:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0a/e3177d0ec99e671e074fdb36cb1505e1da70e5d01cf325280af2116e8548/loro-1.5.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8a6c8e3150da27f24117728c3b8a7fe07265777738c6ffac3bc0f693b680af8e", size = 3285895, upload-time = "2025-08-14T08:53:59.614Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/27/9ec20db627f9073ac2f299647597777daa1e462010989560a8bf634057da/loro-1.5.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c950859e3a932dafebadd01da20e5356f7f0df5b0f85a38c6b48dbc3a3a9070b", size = 3227213, upload-time = "2025-08-14T08:56:02.319Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c0/a8fa26601df2d47ad09a49d759225042535fad763b4323692be7d4a8b3b5/loro-1.5.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:94fcf65b3b970dfcd4078a3c9ab44de89e2805b4fd3591bdf43c92de12661c39", size = 3522480, upload-time = "2025-08-14T08:55:03.267Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/cd/d0207288055fbee64648ad44199660ab94411752bf9498b7f7473c016138/loro-1.5.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9ccaf9327cf26d6c00f014df0857ee75c3b39e401b4034ca76cef05d90da9f53", size = 3282601, upload-time = "2025-08-14T08:59:00.632Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e3/0aaed00bf0e9538e7d69b75fff4ea206cfabb1665276444011648865a51a/loro-1.5.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:d5f7c4c6b96d7cc778314a581b586390d779b3b233a3befe6794501f29c8b32b", size = 3451590, upload-time = "2025-08-14T14:10:05.447Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ce/c99e089fefcd0abc59a5c067af2f9f61441f8c139982dd2640894f25ce5e/loro-1.5.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:94ae0927a4ac24114c812366cbb7911b806f34726a3280543a1e062e7a9a38c8", size = 3520723, upload-time = "2025-08-14T14:10:38.52Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a8/63b5300caf19e1a5d4852c25320cc1cf0255feff2c1b5147f9d848317cfe/loro-1.5.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7f5b0bcc6c7fb6a7b6b14949ff6436196414cd4f8551e00de2a86f709bb95caa", size = 3396595, upload-time = "2025-08-14T14:11:09.805Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/46/0a6f3554a53617172a775fd5e7c5562e8c8cba03044fed532b9ceb75b981/loro-1.5.4-cp310-cp310-win32.whl", hash = "sha256:184ed01f217f110a7defd8c06f1e2eced3028c7f85aa711fb71b3b9ffac9fa72", size = 2584180, upload-time = "2025-08-14T14:11:59.515Z" },
+    { url = "https://files.pythonhosted.org/packages/59/de/5153bf43a65fb4372fecdf0085148ba2bdf0550ba002709f2553587a6917/loro-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:b277d6790cb03206dc9389c7136c5360ab75c3cbb6fe30d98e0bb4b273169b95", size = 2744314, upload-time = "2025-08-14T14:11:40.811Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/c74df6499d20a38e04993ca0da0aafe054108b42c5ab2e3fe01acd9ca991/loro-1.5.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:330d82b5c5b4af5126f4884e938ed636799f0d27884ea497667856e8d5893774", size = 3108196, upload-time = "2025-08-14T08:58:05.641Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c7/587c57d8541d65ba5e2cd858a2ca2a7629a029a5965fea91a627ed67d08a/loro-1.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:eb7a78aac9c2c29ba831a016c9ba6819ad12d8c60f5391479e2be72cc2982a99", size = 2908942, upload-time = "2025-08-14T08:57:39.524Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f1/ca03430e33805ed186497ce18ac546cfd0a551b13d026b0c1564a8a8dc4c/loro-1.5.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82ef6a6de2d3cf15259f2d06810288fce6c46e767c3b34150f9e49e1eb2608d0", size = 3125757, upload-time = "2025-08-14T08:50:46.692Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a2/a9abd3fe3a2e36dfc0efb542b20c8b5911e4774bd013599f1c67fabf79c1/loro-1.5.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b71170342e4eca0823832de0ed3e2d9e1ea54b8562fc51059a2fac1484c3c2b1", size = 3183503, upload-time = "2025-08-14T08:51:52.139Z" },
+    { url = "https://files.pythonhosted.org/packages/01/23/229194a67e9404b9121e7fbcab5530fa5198314fa7bbba0169a60c11ce16/loro-1.5.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:81896117375927da329b6df893ad50aa7c526b5c6d59beefb58f2904e2bdc28f", size = 3580878, upload-time = "2025-08-14T08:52:55.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f4/4c6ed29b76875f0a351ec355be9ba5389f9d365252ef02ceedc915710be7/loro-1.5.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:071d088e2c8aff3a479ae3f812de0cb8257ee4e4eb6e558731a8c2ece113e00e", size = 3285747, upload-time = "2025-08-14T08:54:01.565Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2d/304d4bfd612bbb4ba0306a8751f7b3c0c61048a9a281781ad2734164bf36/loro-1.5.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c09d43e60dda61257ad097d80c9288b75d1b05984ba3121c957b34e74afcb2b", size = 3227491, upload-time = "2025-08-14T08:56:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5d/e8760c5ea4a8a63bdf0557f8121c0ad287c07b767aeaa1a04ddcaa66ad1c/loro-1.5.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f18e3176915b0abb36cf28319ea6cc8ef7f527092b32e506b2d65e8c2518c604", size = 3522824, upload-time = "2025-08-14T08:55:05.166Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/cc7a05b3ca9eaf74f67329302a18252914d640e8182ed922cab3c5ae7cb2/loro-1.5.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0761b5a994e3530ed2e2b64251e2f911bd2f25f4a9b959b6e23bc914e69c5c63", size = 3282322, upload-time = "2025-08-14T08:59:02.365Z" },
+    { url = "https://files.pythonhosted.org/packages/09/3a/cc7f3eff3b6efb3320777be4655a8bd550f9a2cf3e529d9efe36a0fcf1d3/loro-1.5.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:dc87d46d216659a7686e262c2b12de6df092204c1a7beb52a0ae450597b82cf2", size = 3451667, upload-time = "2025-08-14T14:10:07.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d5/b1cf39c3fa040b7243315f4c18c831ae64d67e83b91d461502d65686e2f4/loro-1.5.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:56369a4c2207b0fd5098d52204b78859f91557fe61d38d25c4a1720208394c25", size = 3520536, upload-time = "2025-08-14T14:10:40.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/4a/257ef21ced6005b75d5612664a9633017d3cd5cdf8caaa5668adaa3177c7/loro-1.5.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a8f73e0c122887cda124b15f28ac1a83cb77639fa9d55de085db9005af1243c8", size = 3396378, upload-time = "2025-08-14T14:11:11.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7e/fa17b5dfccd1ca3eff9321a504d4ba83dbb8d0b6f81b5e50e58d796edbb0/loro-1.5.4-cp311-cp311-win32.whl", hash = "sha256:4d28e4f1f158d4ecf957d308d6abbe4c129470690d4ceda18461ebda4bc39bd0", size = 2584122, upload-time = "2025-08-14T14:12:00.829Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8e/f1edd5fe08610ee2e5287edf52ad73ebe6c7ad95678720a755c5717b66fb/loro-1.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:724eb1a40c249fa80b6771208eb95275956e86f3962ba54af42ad5d610e303e8", size = 2744396, upload-time = "2025-08-14T14:11:42.955Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/77/f18d2e7bbf46637c859b362c55734e988b545a3459755512ac815ed5214e/loro-1.5.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:11ac98eab1fc7585f5ed9f93375ff5f89cdf37554ae38644209a8513af641fa2", size = 3080787, upload-time = "2025-08-14T08:58:07.398Z" },
+    { url = "https://files.pythonhosted.org/packages/38/08/38be729fdf5ea19880f16bb0cac784d6f77535b87d9b9e67966b2ee3018e/loro-1.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8ff7ad401e8a655c51dafb990761eb944ea80e23c8bea97acb41b48ee475c6b", size = 2887846, upload-time = "2025-08-14T08:57:41.586Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a9/076b35fcb523f899701eecff4a94dd67f170f4d43e5abe36cf306d989262/loro-1.5.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1aa15e3c434a8722129400c1a32570d6e782b8e94f5280d7a0988db924f294d", size = 3129067, upload-time = "2025-08-14T08:50:48.392Z" },
+    { url = "https://files.pythonhosted.org/packages/81/30/5dcfc518ed1a58f2bc87ae0877ff5c22157b91c17818dca1ab5e23a2b7bd/loro-1.5.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3300552a3ef18403486a6d726f7a58079af28a0f132f264977b4e92caef33a10", size = 3193576, upload-time = "2025-08-14T08:51:53.994Z" },
+    { url = "https://files.pythonhosted.org/packages/63/0c/c7142862fa2b5e9b0b4079140ad2d83ca7ec0e18eeba33e282fb81a444cf/loro-1.5.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:acbfd9067e83d7790fe3f897b5842aa726c4b7048dce094326a3b81cd56c3ee7", size = 3581554, upload-time = "2025-08-14T08:52:57.961Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ec/853484f10958e8bd766aea45e174b5f9d52dd1618ad7ded33fe19b79af4d/loro-1.5.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c0590ff028e838b72cbebcb7276463675d1b7b24d4ff7d004a0de15fa3ce170", size = 3294156, upload-time = "2025-08-14T08:54:03.44Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/bfc033e08206143fe4a2e845a13b3d4a367f88141185b1288f161356d5e2/loro-1.5.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dac8b50d9e04603883e2fb3952b9069f2f8ef9cd5c50d468b68e6c390abc655", size = 3233554, upload-time = "2025-08-14T08:56:06.992Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/b2d42d0b5b8381edd33b0d39f3796541630241aa37908dc6ae6013145b61/loro-1.5.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4d4638fcae138033df766ed59aac451778e33b066b91fda5d0e775c651baf16f", size = 3524368, upload-time = "2025-08-14T08:55:06.801Z" },
+    { url = "https://files.pythonhosted.org/packages/21/79/e63d33d65bc771dc0585c5e0af44849393023cee6c9ced68be24c03bd786/loro-1.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:843241f6c0c20199ec1ba38c379121efb0424fc7b5a9d2167d73bd83912185ff", size = 3285397, upload-time = "2025-08-14T08:59:04.126Z" },
+    { url = "https://files.pythonhosted.org/packages/00/52/b0e7702d7b0941338a496944f37a24e9d7b425e38619322cc54dba78feb4/loro-1.5.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:498c6f4419b6ef559e5319d06343be5de95ef7a32582569d0c040054cf984d06", size = 3459776, upload-time = "2025-08-14T14:10:08.865Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/1b8e1dffec0f53065a4c145ee94c209a72823b81eba0d2016790101be1a6/loro-1.5.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:176418073efa149cc215995fd17fea85cfe815e1acdf4279969c4791abef359c", size = 3522809, upload-time = "2025-08-14T14:10:41.689Z" },
+    { url = "https://files.pythonhosted.org/packages/94/62/90024eea45fcf44a39b95dc944445d9f5e59a6692c05d138d081d18a43c6/loro-1.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:59bbadcf48ba96594fb75d75fef5e607f28fb6489eb1f9ccf6cb826315624d19", size = 3402879, upload-time = "2025-08-14T14:11:12.494Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9c/57a92a49f51f0b63b28224d2fce33caa3b0a7160ee578cf1e96c538e3108/loro-1.5.4-cp312-cp312-win32.whl", hash = "sha256:859d75608c4331cfb5177809de1f82e06791a1d8ff3af71331a1d479f1aed4af", size = 2583524, upload-time = "2025-08-14T14:12:02.337Z" },
+    { url = "https://files.pythonhosted.org/packages/68/23/6b4bd5f7a8e0d9343d53b73eaab038db7fe06f9542ff1f65b4a435026202/loro-1.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:a685373e1c20f86af26f815ce615f310e09d48cf2ad65a911cab342a855c33a3", size = 2742037, upload-time = "2025-08-14T14:11:44.825Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/77/85301e4bce40d3d622e4c97476ea3ca33dca37855422075a8710397c86d0/loro-1.5.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f19d5c97647648da8f0e325cd91f5a54e73184a0ba63c8dbb90c42c03c56c3bf", size = 3080911, upload-time = "2025-08-14T08:58:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6a/c4417f907b2c570c4b8f71a20acb023b7800825f9202b659d785c22f4e89/loro-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:da505a753581e3f0c25b917258b83169671ae9890a834e0c13b7ec42f8a1e3e9", size = 2886634, upload-time = "2025-08-14T08:57:43.308Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f2/c4d427a7d5fa78b3743571ae67f69056bd3d62f4053be839d707e8e1c0e5/loro-1.5.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c0a7496b40e47a0859ce5f6d077b0e2a3f7d472203c5c4427a4a62a184a02b3", size = 3128155, upload-time = "2025-08-14T08:50:50.451Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/51/9a47bdbd8d9735192f9de2f3b80e001a5a0f804c2839d4a2bc44839a3a4e/loro-1.5.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:114bfc0252356301880f13be95cda20452b44cfad0fb34727d41abc935e3304c", size = 3193298, upload-time = "2025-08-14T08:51:55.698Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c6/4b4325cee540b29c502c61a88ca9a607f8141dfc0ba2aef85b3d09a392b1/loro-1.5.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f6c1959034edc73db1b91b97c1f2ffce9842848af765e1dd787dfac2c54ee39f", size = 3579895, upload-time = "2025-08-14T08:52:59.745Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/91/2f521dc0c87acff991ef27914f9ff9d42ca6dc432f86e95a862f69195ac9/loro-1.5.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd4560f90b0e36ace65e66cef92255cfdcf592c1cc708d1290af1b88740e20bd", size = 3293812, upload-time = "2025-08-14T08:54:05.387Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ec/3c17389391ab83a6e7d4a661c4bf32e9ebabcee708a23385bd26d9e07745/loro-1.5.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51018dc99fed929b96fd111d562507de3b8702e7da952763ed21584b6de5f8e4", size = 3233172, upload-time = "2025-08-14T08:56:08.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c9/20324bb35478fb72e9514c754219da9887729d6cbf242c6013cdf13d81e7/loro-1.5.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9136ef2280af0381d22d52adb5edcfb89d5693fba2b5e9691d006f08998bdf97", size = 3523042, upload-time = "2025-08-14T08:55:08.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9d/9aa53bc4831ffb52252bd1d5749f58b2681f6c3a58df4ba812a19486182e/loro-1.5.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e8960e8f044b18e211c5861e40de0f65d3bc41ecbd7ca31a4686990604700a91", size = 3284831, upload-time = "2025-08-14T08:59:05.78Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/c072df8c0567560714ddbfbd461d49d45ba4cfe8051d2a15dd7ed752c214/loro-1.5.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5d4fdf595fe5bbdf173e32c4c1bf581d48876111400a21f5067b2d4c4efdf9a0", size = 3460028, upload-time = "2025-08-14T14:10:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/50/36/ae1786609fd3b5ac0b02db04b880ce3a2d4ce56f6c8ebf99a6352b2166e5/loro-1.5.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1cb2025339a379cf87bdd3aaa8ed2af126e9c78259797fe752502e6431d35630", size = 3522407, upload-time = "2025-08-14T14:10:43.039Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/5e/64641ee4ac7d5c60b69dec65803b7152055dc7560c257741f95f80b7760f/loro-1.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444bfc9211d6b09383cebd4e7e536083e75adb6668d3e039a67b6de2953b8e47", size = 3403032, upload-time = "2025-08-14T14:11:13.789Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/39/e3ea047f10716490ef1e1b20683fe6dbb795ca5f41e001920e4bbbdef89f/loro-1.5.4-cp313-cp313-win32.whl", hash = "sha256:b80c598c44aded4264fe5ddfaaae4b785d9996916fe5d5bea747948a174bac01", size = 2583310, upload-time = "2025-08-14T14:12:03.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/66/60809f76869de6fb474b983eb053a59805e1c14965eec04089454f3e493f/loro-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:66376a13cebf6777a5ab0a47e40171848879609668160034877f4b50f2ba6d58", size = 2742115, upload-time = "2025-08-14T14:11:46.125Z" },
+    { url = "https://files.pythonhosted.org/packages/65/3d/eacc3501655c1b3b13f0c9f32727cd696990219760926f194a1af859a8a4/loro-1.5.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7e68a414921c9a21249f777b24fb76cab02805190aa654dbe327177c7e43a45", size = 3123301, upload-time = "2025-08-14T08:50:52.417Z" },
+    { url = "https://files.pythonhosted.org/packages/74/06/a2f84b847b3408a2e1356eff03c275d78cb47c6a8723ff80af09393609ec/loro-1.5.4-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e770e7e50ca10a0e24089aae204575df392b1f47352231301de8a6a4e181efa5", size = 3176983, upload-time = "2025-08-14T08:51:57.652Z" },
+    { url = "https://files.pythonhosted.org/packages/56/35/e3782a17e3ec4c73eaf49feedbd5165a9f15d5113ce1b6d06975c6615edb/loro-1.5.4-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5e5eeb363314259e563ac31f4af7b22dc17ce72bed91bf0a78a61378fdb6b10f", size = 3578580, upload-time = "2025-08-14T08:53:01.345Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b3/42f5ffcebd089acf7cd2e9d39f9ce06bd86495904dbe34ae6e715806b923/loro-1.5.4-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0b6146f915fe26b29aec2ebcac543badf084a39a178f7eaab07d7beb1b0b77aa", size = 3288659, upload-time = "2025-08-14T08:54:07.315Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/71/7161b00bcf88b7c5578c5c383d8f1f644e82b6c7693a0413680366a295fb/loro-1.5.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f25bb740aa360d4c8f9fed30e3b4cd615ea9f58cc1d1f01ec62e11784d0ca29d", size = 3277475, upload-time = "2025-08-14T08:59:07.652Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/81ae72fd3aea4bcd17666db0aafb03fff5d77b3e7f75f27fcd1546135ed8/loro-1.5.4-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:fb0aadd8796b376ab25c4acee0227089d4ae1883a905147e091ac87f3d61fe3d", size = 3445844, upload-time = "2025-08-14T14:10:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d5/e01eb9165107b1a808018ec911886475a36beffe284a10d48162901de378/loro-1.5.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:74cda80bc4b7d436d9c84ffd93950a1fcc308be498e8f04641dc0d317a77a315", size = 3511421, upload-time = "2025-08-14T14:10:44.618Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b2/8f9c77bfe61c102b48d6a592385e7950b5c2ae3920ba91c01ce3c7e889ff/loro-1.5.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:89e91a0a90afbdc5925d4e04b46c29fe82b2ad9acde18ec6df8be1ee8ea787ad", size = 3398523, upload-time = "2025-08-14T14:11:15.366Z" },
+    { url = "https://files.pythonhosted.org/packages/07/20/f87932e43e5915b8d296ef95003fc1e9af88082196b6788d964866d049df/loro-1.5.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:5b870ebe934734fdf3c63b4ce6539b64297c1db25ed90534ba0c9dca3d4b55bd", size = 3094378, upload-time = "2025-08-14T08:58:50.186Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c4/eb3694a10b9659df238a71add27e6d600e0f2597979edabd30cc54e409aa/loro-1.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:21297974d6b7853f4b41aa67478432b38ea664f730d26c6ef3fc5c525934fc8e", size = 2884760, upload-time = "2025-08-14T08:57:53.699Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4f/823a6dced4e777b51ad71b3df82242152d03ab7ce591b661ada13c124d11/loro-1.5.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd2df3fdee10d6f1f3848efb046edf35588fb78f33275b75daf59bbd5265c12a", size = 3234022, upload-time = "2025-08-14T08:56:10.413Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/47eb48e175311e8beba55e68e532b4edf006d3dead8d2b6ceba55ad960fb/loro-1.5.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d7000c1217f0e524eeecc67937de358755476deee61925b43c3e65ffdf2e148", size = 3523910, upload-time = "2025-08-14T08:55:10.326Z" },
+    { url = "https://files.pythonhosted.org/packages/91/22/4b2a552d1bd5188db9f483036ea39e847ea3f4e30970d6a0808601938c55/loro-1.5.4-cp314-cp314-win32.whl", hash = "sha256:ba809df6c9ac8a462e585e14cc32ef007ef7a11e38204594598f1ceeb5016d04", size = 2585639, upload-time = "2025-08-14T14:12:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ee/88f46ee0cb566a39a9d9bd427d487b07ca2b054825f76d5c86009733af9c/loro-1.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:540caa046d62145ea71e85231ab032fe643ce356aa87d0c0a203e8e607810c90", size = 2747968, upload-time = "2025-08-14T14:11:53.703Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/49/66b569945ec158209d22320c216dcce65b8c87f744c07e57c6f0a3e42d4f/loro-1.5.4-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87183691bf5cf8139f8b01a6faa8281ea35cc72487ec90dc4504f994f9e60948", size = 3123181, upload-time = "2025-08-14T08:50:58.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/93/47a9a500f837d9a0044ddd5d163e4c40a5b523ed68e3db40a8f730c815c8/loro-1.5.4-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1074901a72de171b4d105b29e1fa135f5048f0cb7c1631fa40e255e061d18679", size = 3182734, upload-time = "2025-08-14T08:52:03.438Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/0eb2f8f3dc64ffcbd5a7b2208a3dde2826317a3c564966940348050cd860/loro-1.5.4-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e075888bcbb251d4f5e937381399983b801a7c913cfc36abec67854f612acde5", size = 3580447, upload-time = "2025-08-14T08:53:07.236Z" },
+    { url = "https://files.pythonhosted.org/packages/83/70/ad2eebe63089f9ae23a465a8b146bff668906306e103112331524b6954cb/loro-1.5.4-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69fcb76722a508f3730afd2152dabaef06198a6bece96e4ab2b04fcc7b170fe9", size = 3283925, upload-time = "2025-08-14T08:54:13.286Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e3/9e69c077129fc8c2c6738bf36f7ef8c6e2ce3d6ca5378bea05ea5ad9188f/loro-1.5.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e44bf7cc31649a8f34062c3bc544c5ef1b1d5f63c1e9767656775c6d0488d67", size = 3226526, upload-time = "2025-08-14T08:56:15.807Z" },
+    { url = "https://files.pythonhosted.org/packages/58/6e/29c24b8da0245efd84570e1aa8e5e98b0cbc2797c4c87653e90ea686617b/loro-1.5.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:39acd41c91148549357e030f006351b7d20190dc31efdd2dcc5f1e7560730d38", size = 3521101, upload-time = "2025-08-14T08:55:15.603Z" },
+    { url = "https://files.pythonhosted.org/packages/08/1a/537af6d8fd823e0ed0bfed4411a372eae6a6bc32b272a7df3be65f242efb/loro-1.5.4-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:0ce6d2563d5dc20b1322c3039d5f2791570633d3680909fec72e9720c6401235", size = 3279969, upload-time = "2025-08-14T08:59:13.112Z" },
+    { url = "https://files.pythonhosted.org/packages/af/68/69a65068f6c5eddde149b9cbb539930ca26491cc3ee4fc517c28cca801f6/loro-1.5.4-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:9d0089e69b6d3080e0a2614cb87b310a23ddcea1a607c15c56022fb0827af887", size = 3451548, upload-time = "2025-08-14T14:10:17.17Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ca/1ef6f9cd94e131a69932215cf0329729f36e985fe770b4c1844a72f702c2/loro-1.5.4-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:cc152afa5e0f779308cb79f655988a5a57ab8c08717e1e67069198eee03a63ed", size = 3520011, upload-time = "2025-08-14T14:10:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/15/f7057f92c3cbbfdc4b33e58c25a857c3e54dc4b408ff3db55272c3184aa5/loro-1.5.4-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:d000b73eb2a378cac2bee185bd185e64b7359b58326a3c5f964409112d4d6688", size = 3397082, upload-time = "2025-08-14T14:11:19.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/19/041cf10b95513d165404652236fb2c7ec6f62ccb0ff4c2ea0da470476de0/loro-1.5.4-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fe859d038a18e043e18478c9781ae6ed34368b597ca2e734f4261f554dd6f2d", size = 3123507, upload-time = "2025-08-14T08:51:00.291Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/57/7b72f401092870a7f113e988a10f5ccd9284e01dee2b2c7b90fa9fe4606a/loro-1.5.4-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75d100adbfa1fda145fb1d88369d244cfa67348d50fe968ec6451c44fcb12899", size = 3183394, upload-time = "2025-08-14T08:52:05.288Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ae/fed96060761f9b85ada228f6ea3f2c3b74fd35971ba3b6bbf91b558f9931/loro-1.5.4-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c2c4397c25e356b7b42c546509262fa5cb2351144ec1223fe6d2733b01429cbf", size = 3580599, upload-time = "2025-08-14T08:53:08.984Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/3a/d7c01f6d514e7c3085f603bfd05186b88d525c458d8e1b1b8fa6edfa3982/loro-1.5.4-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d086a24074300958bbe2e9a35fd4eabc3ef8ce6a082399d7c00f8299d2da03e3", size = 3284180, upload-time = "2025-08-14T08:54:15.109Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/49/5608596b7b94f45bee54a5bae08110e1d3484f540625262e68bc6645bf75/loro-1.5.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f9ae531b15c2baa80ea86a4f51919720b2ce928431d3b59136f6a6578cccd1e", size = 3226468, upload-time = "2025-08-14T08:56:17.76Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/49/2a30e3db4224886dfcd26d918b387bca6cc3a73f2437b731fc66b0048c53/loro-1.5.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af1ca8c4297280c8abdbf13db1fb798b1d05b6f6a6c0c6d3bfb54f3198745b5f", size = 3521508, upload-time = "2025-08-14T08:55:17.807Z" },
+    { url = "https://files.pythonhosted.org/packages/19/39/a17528564f4454c8a30229993d841bfd83e71c1a59fb031f2576d0ebc5b7/loro-1.5.4-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:06765745f4a572b7da84aefc4919933971ae9c9f0f7c27d5ef2506c15480f121", size = 3280223, upload-time = "2025-08-14T08:59:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3d/958aad3d9337d1207c31d8d50f6dd3c8a5760e6f0abfc92292ced0f9062a/loro-1.5.4-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:75eb8e015cc7ed1f35145f73eb7dda08e360b2b24ae49c4cf0346d6a64e92f3b", size = 3451176, upload-time = "2025-08-14T14:10:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/42/60/d2c289f4b802a147ece9c0e43729bc5d98731e4f6fe008e4b64cbefa4810/loro-1.5.4-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:10e8388655843b06f64a7869206d345a6c72974dc3ab0967819e0e50704c857f", size = 3520366, upload-time = "2025-08-14T14:10:50.342Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/62/161f9d0bf5169be07cb4139d2c1a55496dd1c00ac8acdeace325c2374faa/loro-1.5.4-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:70313496189443a1ebbc84286ca8b42c65af635807d6ae66ea306992283ee95c", size = 3397061, upload-time = "2025-08-14T14:11:21.139Z" },
+]
+
+[[package]]
+name = "marimo"
+version = "0.14.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "docutils" },
+    { name = "itsdangerous" },
+    { name = "jedi" },
+    { name = "loro", marker = "python_full_version >= '3.11'" },
+    { name = "markdown" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "pyyaml" },
+    { name = "starlette" },
+    { name = "tomlkit" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/2a/f0ce506e78e49ae0fe567ae23418e9af759c0272ac46c91a7d5ed8e92777/marimo-0.14.17.tar.gz", hash = "sha256:f38e592b83f8c23a0f19ef32d845594f6566691c28b1e41d04a78156df953305", size = 30581473, upload-time = "2025-08-11T19:31:16.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/23/ca5f37ea5f6d0e22e8ba1bb6c2d00b44d8178ec5c5b10dad9d17e3561886/marimo-0.14.17-py3-none-any.whl", hash = "sha256:88e2b3fe86567c322805a5faebcc18e302813b109e017e1104157e44b8659777", size = 30819777, upload-time = "2025-08-11T19:31:12.049Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/c2/4ab49206c17f75cb08d6311171f2d65798988db4360c4d1485bd0eedd67c/markdown-3.8.2.tar.gz", hash = "sha256:247b9a70dd12e27f67431ce62523e675b866d254f900c4fe75ce3dda62237c45", size = 362071, upload-time = "2025-06-19T17:12:44.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/2b/34cc11786bc00d0f04d0f5fdc3a2b1ae0b6239eef72d3d345805f9ad92a1/markdown-3.8.2-py3-none-any.whl", hash = "sha256:5c83764dbd4e00bdd94d85a19b8d55ccca20fe35b2e678a1422b380324dd5f24", size = 106827, upload-time = "2025-06-19T17:12:42.994Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/f0/b0550d9b84759f4d045fd43da2f811e8b23dc2001e38c3254456da7f3adb/narwhals-2.1.2.tar.gz", hash = "sha256:afb9597e76d5b38c2c4b7c37d27a2418b8cc8049a66b8a5aca9581c92ae8f8bf", size = 533772, upload-time = "2025-08-15T08:24:50.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/01/824fff6789ce92a53242d24b6f5f3a982df2f610c51020f934bf878d2a99/narwhals-2.1.2-py3-none-any.whl", hash = "sha256:136b2f533a4eb3245c54254f137c5d14cef5c4668cff67dc6e911a602acd3547", size = 392064, upload-time = "2025-08-15T08:24:48.788Z" },
 ]
 
 [[package]]
@@ -441,6 +662,15 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609, upload-time = "2024-04-05T09:43:55.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650, upload-time = "2024-04-05T09:43:53.299Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -486,6 +716,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003, upload-time = "2025-02-13T21:54:07.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051, upload-time = "2025-02-13T21:54:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da", size = 239535, upload-time = "2025-02-13T21:54:16.07Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ed/d362e84620dd22876b55389248e522338ed1bf134a5edd3b8231d7207f6d/psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91", size = 275004, upload-time = "2025-02-13T21:54:18.662Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34", size = 277986, upload-time = "2025-02-13T21:54:21.811Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993", size = 279544, upload-time = "2025-02-13T21:54:24.68Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053, upload-time = "2025-02-13T21:54:34.31Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885, upload-time = "2025-02-13T21:54:37.486Z" },
 ]
 
 [[package]]
@@ -538,6 +783,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
 ]
 
 [[package]]
@@ -647,6 +905,28 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.47.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -686,6 +966,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -704,6 +993,20 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "20.34.0"
 source = { registry = "https://pypi.org/simple" }
@@ -716,6 +1019,65 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080, upload-time = "2025-03-05T20:01:37.304Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329, upload-time = "2025-03-05T20:01:39.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312, upload-time = "2025-03-05T20:01:41.815Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319, upload-time = "2025-03-05T20:01:43.967Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631, upload-time = "2025-03-05T20:01:46.104Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016, upload-time = "2025-03-05T20:01:47.603Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426, upload-time = "2025-03-05T20:01:48.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360, upload-time = "2025-03-05T20:01:50.938Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388, upload-time = "2025-03-05T20:01:52.213Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830, upload-time = "2025-03-05T20:01:53.922Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "loguru" },
     { name = "marimo" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -177,12 +176,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bson", specifier = ">=0.5.10" },
-    { name = "loguru", marker = "extra == 'dev'", specifier = ">=0.7.0" },
-    { name = "marimo", marker = "extra == 'dev'", specifier = "==0.14.17" },
+    { name = "marimo", marker = "extra == 'dev'", specifier = "~=0.14.17" },
     { name = "numpy", specifier = ">=2" },
     { name = "pandas", specifier = ">=2" },
     { name = "polars", specifier = ">=1.16.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.1" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "pyarrow", specifier = ">=18.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
@@ -283,19 +281,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
-]
-
-[[package]]
-name = "loguru"
-version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -1076,13 +1061,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
-]
-
-[[package]]
-name = "win32-setctime"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,6 @@ dependencies = [
     { name = "pandas" },
     { name = "polars" },
     { name = "pyarrow" },
-    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -187,7 +186,6 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=18.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
This PR updates config files from [tschm/.config-templates](https://github.com/tschm/.config-templates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Code of Conduct and CONTRIBUTING; expanded docs, notebook demos, README doctest validation, and in-repo examples.

* **Chores**
  * Added task-runner automation, multiple taskfiles, Makefile and editorconfig updates, linter config, expanded .gitignore, pre-commit adjustments, Ruff config, devcontainer reoriented to a Marimo-focused setup, and dev dependency tweaks.

* **CI**
  * Reworked GitHub workflows: CI, pre-commit, deptry, Marimo notebook runs, consolidated book/Pages pipeline, and a multi-stage release workflow.

* **Tests**
  * Added end-to-end taskfile tests and broadened serialization and docs-related test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->